### PR TITLE
Add filter to "This is a gift" text and improve i18n of recipient template

### DIFF
--- a/templates/html-add-recipient.php
+++ b/templates/html-add-recipient.php
@@ -1,5 +1,6 @@
 <fieldset>
-	<input type="checkbox" id="gifting_<?php esc_attr_e( $id, 'woocommerce_subscriptions_gifting' ) ?>_option" class="woocommerce_subscription_gifting_checkbox" value="gift" <?php esc_attr_e( ( empty( $email ) ) ? '' : 'checked', 'woocommerce_subscriptions_gifting' ) ?> /> <?php echo esc_html__( 'This is a gift', 'woocommerce_subscriptions_gifting' ) ?> <br />
+	<input type="checkbox" id="gifting_<?php esc_attr_e( $id, 'woocommerce_subscriptions_gifting' ) ?>_option" class="woocommerce_subscription_gifting_checkbox" value="gift" <?php esc_attr_e( ( empty( $email ) ) ? '' : 'checked', 'woocommerce_subscriptions_gifting' ) ?> />
+	<?php echo esc_html( apply_filters( 'wcsg_enable_gifting_checkbox_label', __( 'This is a gift', 'woocommerce_subscriptions_gifting' ) ) ); ?> <br />
 	<p class="form-row form-row <?php esc_attr_e( implode( ' ', $email_field_args['class'] ) ); ?>" style="<?php esc_attr_e( implode( '; ', $email_field_args['style_attributes'] ) );?>">
 		<label for="recipient_email[<?php esc_attr_e( $id );?>]">
 			<?php esc_html_e( "Recipient's Email Address:", 'woocommerce-subscriptions-gifting' ); ?>

--- a/templates/html-add-recipient.php
+++ b/templates/html-add-recipient.php
@@ -1,7 +1,9 @@
 <fieldset>
 	<input type="checkbox" id="gifting_<?php esc_attr_e( $id, 'woocommerce_subscriptions_gifting' ) ?>_option" class="woocommerce_subscription_gifting_checkbox" value="gift" <?php esc_attr_e( ( empty( $email ) ) ? '' : 'checked', 'woocommerce_subscriptions_gifting' ) ?> /> <?php echo esc_html__( 'This is a gift', 'woocommerce_subscriptions_gifting' ) ?> <br />
 	<p class="form-row form-row <?php esc_attr_e( implode( ' ', $email_field_args['class'] ) ); ?>" style="<?php esc_attr_e( implode( '; ', $email_field_args['style_attributes'] ) );?>">
-		<label for="recipient_email[<?php esc_attr_e( $id );?>]">Recipient's Email Address:</label>
+		<label for="recipient_email[<?php esc_attr_e( $id );?>]">
+			<?php esc_html_e( "Recipient's Email Address:", 'woocommerce-subscriptions-gifting' ); ?>
+		</label>
 		<input type="email" class="input-text recipient_email" name="recipient_email[<?php esc_attr_e( $id );?>]" id="recipient_email[<?php esc_attr_e( $id );?>]" placeholder="<?php esc_attr_e( $email_field_args['placeholder'] );?>" value="<?php esc_attr_e( $email )?>"/>
 		<?php wp_nonce_field( 'wcsg_add_recipient', '_wcsgnonce' ); ?>
 	</p>


### PR DESCRIPTION
Pass _"This is a gift"_ label through a filter so that it can be customised without the need for overriding the template. Also make sure _Recipient's Email Address:_ is made available for translation.