### PR TITLE
Fix interactive gifting fields being added to the mini cart in some situations

### DIFF
--- a/includes/class-wcsg-cart.php
+++ b/includes/class-wcsg-cart.php
@@ -23,7 +23,7 @@ class WCSG_Cart {
 	 */
 	public static function add_gifting_option_cart( $title, $cart_item, $cart_item_key ) {
 
-		$is_mini_cart = ( did_action( 'woocommerce_before_mini_cart' ) > did_action( 'woocommerce_after_mini_cart' ) ) ? true : false;
+		$is_mini_cart = did_action( 'woocommerce_before_mini_cart' ) && ! did_action( 'woocommerce_after_mini_cart' );
 
 		if ( is_cart() && ! $is_mini_cart ) {
 			$title .= self::maybe_display_gifting_information( $cart_item, $cart_item_key );

--- a/includes/class-wcsg-cart.php
+++ b/includes/class-wcsg-cart.php
@@ -23,7 +23,9 @@ class WCSG_Cart {
 	 */
 	public static function add_gifting_option_cart( $title, $cart_item, $cart_item_key ) {
 
-		if ( is_cart() && ! in_array( 'get_refreshed_fragments', $_GET ) ) {
+		$is_mini_cart = ( did_action( 'woocommerce_before_mini_cart' ) > did_action( 'woocommerce_after_mini_cart' ) ) ? true : false;
+
+		if ( is_cart() && ! $is_mini_cart ) {
 			$title .= self::maybe_display_gifting_information( $cart_item, $cart_item_key );
 		}
 


### PR DESCRIPTION
When adding a product to the cart from the shop/product archive page, the mini cart will be incorrectly generated with interactive gifting fields.

Before: https://cloudup.com/iP05CfAz2Sz
After adding the daily product from the shop page: https://cloudup.com/inasA0BMAKY

This PR uses a more consistent and reliable approach to determining if the `woocommerce_cart_item_name` is being generated for the mini cart or cart page rather than the approach introduced in https://github.com/Prospress/woocommerce-subscriptions-gifting/commit/a0e2b2238d9a03d8660efe6d91c688aaf0439dcf.