### PR TITLE
Remove references to 'Gift' in customer facing notices and add "This is a gift" setting 

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,11 @@ To install Gifting:
 1. Click **Install Now**
 1. Click **Activate**
 
+### Corporate Purchasing
+As well as purchasing gifts for family and friends, Gifting's underlying logic is also suited to corporate purchasing. When communicating with the purchaser or recipient, more generic terminology, like "Recipient", and more generic phrases, like "purchased a subscription for you" are used so that Gifting can be used in both scenarios with very little customisability required. The only reference to the word 'gift' in customer-facing text is the checkbox label,  _"This is a gift"_, displayed on the Single Product, Checkout and Cart pages (see the [Customer's View](https://github.com/Prospress/woocommerce-subscriptions-gifting#customers-view) section). This text is configurable via a setting in **WooCommerce > Settings > Subscriptions**.
+
+![](https://cldup.com/TlpgBAZQpr.png)
+
 ## Customer's View
 
 There are three pages where a customer can choose to purchase a subscription product for someone else:
@@ -142,7 +147,7 @@ The first time the new recipient logs into their account they will be prompted t
 
 ![](https://cldup.com/hbICzQoNWr-3000x3000.png)
 
-<img src="https://cldup.com/dMR6-BEByL-3000x3000.png" height="799" width="409" align="right">
+<img src="https://cldup.com/W_Qf0vhrOr.png" height="778" width="522" align="right">
 #### Shipping Address
 
 When a gifted subscription is purchased, the shipping address of the subscription is set to the recipient's shipping address. This streamlines the process for customers proceeding through the checkout when purchasing subscription products for other users.

--- a/README.md
+++ b/README.md
@@ -23,10 +23,15 @@ To install Gifting:
 1. Click **Install Now**
 1. Click **Activate**
 
-### Corporate Purchasing
-As well as purchasing gifts for family and friends, Gifting's underlying logic is also suited to corporate purchasing. When communicating with the purchaser or recipient, more generic terminology, like "Recipient", and more generic phrases, like "purchased a subscription for you" are used so that Gifting can be used in both scenarios with very little customisability required. The only reference to the word 'gift' in customer-facing text is the checkbox label,  _"This is a gift"_, displayed on the Single Product, Checkout and Cart pages (see the [Customer's View](https://github.com/Prospress/woocommerce-subscriptions-gifting#customers-view) section). This text is configurable via a setting in **WooCommerce > Settings > Subscriptions**.
+After installation, you can customise the way Gifting works by going to **WooCommerce > Settings > Subscriptions** and scrolling down to **Gifting Subscriptions**.
+Here you can: 
+- Customise the label text displayed next to the checkbox on the [Single Product, Cart and Checkout pages](https://github.com/Prospress/woocommerce-subscriptions-gifting#customers-view). By default, the text will display "This is a gift", but you may change this to a phrase which suits your store.
+- Enable or disable granting dual download permissions for downloadable subscription purchases. Learn more about this setting in the [Downloadable Products section](https://github.com/Prospress/woocommerce-subscriptions-gifting#downloadable-products). By default, this feature is disabled. 
 
-![](https://cldup.com/TlpgBAZQpr.png)
+![](https://cldup.com/lwyKqIJ-v6.png)
+
+## Corporate Purchasing
+As well as purchasing gifts for family and friends, Gifting's underlying logic is also suited to corporate purchasing scenarios. If your store revolves around selling corporate products, it's likely a company purchasing officer may wish to buy and manage subscriptions for members of their team. It is for this reason when communicating with the purchaser and recipient, more generic terminology, like  _"Recipient"_, and generic phrases, like _"purchased a subscription for you"_, are used so that Gifting can be applied in corporate purchasing scenarios with very little customisation required.
 
 ## Customer's View
 

--- a/includes/class-wcsg-admin.php
+++ b/includes/class-wcsg-admin.php
@@ -80,7 +80,7 @@ class WCSG_Admin {
 	}
 
 	/**
-	 * Add Gifting specific settings to standard Subscription settings
+	 * Add Gifting specific settings to standard Subscriptions settings
 	 *
 	 * @param array $settings
 	 * @return array $settings

--- a/includes/class-wcsg-admin.php
+++ b/includes/class-wcsg-admin.php
@@ -1,6 +1,8 @@
 <?php
 class WCSG_Admin {
 
+	public static $option_prefix = 'woocommerce_subscriptions_gifting';
+
 	/**
 	 * Setup hooks & filters, when the class is initialised.
 	 */
@@ -9,6 +11,8 @@ class WCSG_Admin {
 		add_filter( 'woocommerce_subscription_list_table_column_content', __CLASS__ . '::display_recipient_name_in_subscription_title', 1, 3 );
 
 		add_filter( 'woocommerce_order_items_meta_get_formatted', __CLASS__ . '::remove_recipient_order_item_meta', 1, 1 );
+
+		add_filter( 'woocommerce_subscription_settings', __CLASS__ . '::add_settings', 10, 1 );
 	}
 
 	/**
@@ -73,6 +77,32 @@ class WCSG_Admin {
 		}
 
 		return $formatted_meta;
+	}
+
+	/**
+	 * Add Gifting specific settings to standard Subscription settings
+	 *
+	 * @param array $settings
+	 * @return array $settings
+	 */
+	public static function add_settings( $settings ) {
+
+		return array_merge( $settings, array(
+			array(
+				'name'     => __( 'Gifting Subscriptions', 'woocommerce-subscriptions-gifting' ),
+				'type'     => 'title',
+				'id'       => self::$option_prefix,
+			),
+			array(
+				'name'     => __( 'Gifting Checkbox Text', 'woocommerce-subscriptions-gifting' ),
+				'desc'     => __( 'Customise the text displayed on the front-end next to the checkbox to select the product/cart item as a gift.', 'woocommerce-subscriptions' ),
+				'id'       => self::$option_prefix . '_gifting_checkbox_text',
+				'default'  => __( 'This is a gift', 'woocommerce-subscriptions-gifting' ),
+				'type'     => 'text',
+				'desc_tip' => true,
+			),
+			array( 'type' => 'sectionend', 'id' => self::$option_prefix ),
+		 ) );
 	}
 }
 WCSG_Admin::init();

--- a/includes/class-wcsg-cart.php
+++ b/includes/class-wcsg-cart.php
@@ -104,7 +104,7 @@ class WCSG_Cart {
 					$subscription = wcs_get_subscription( $item['subscription_renewal']['subscription_id'] );
 					if ( WCS_Gifting::is_gifted_subscription( $subscription ) ) {
 						$passed = false;
-						wc_add_notice( __( 'You can not purchase additional products in gifted subscription renewal orders.', 'woocommerce-subscriptions-gifting' ), 'error' );
+						wc_add_notice( __( 'You cannot add additional products to the cart when the cart contains a subscription renewal order purchased for a recipient.', 'woocommerce-subscriptions-gifting' ), 'error' );
 						break;
 					}
 				}

--- a/includes/class-wcsg-cart.php
+++ b/includes/class-wcsg-cart.php
@@ -104,7 +104,7 @@ class WCSG_Cart {
 					$subscription = wcs_get_subscription( $item['subscription_renewal']['subscription_id'] );
 					if ( WCS_Gifting::is_gifted_subscription( $subscription ) ) {
 						$passed = false;
-						wc_add_notice( __( 'You cannot add additional products to the cart when the cart contains a subscription renewal order purchased for a recipient.', 'woocommerce-subscriptions-gifting' ), 'error' );
+						wc_add_notice( __( 'You cannot add additional products to the cart. Please pay for the subscription renewal first.', 'woocommerce-subscriptions-gifting' ), 'error' );
 						break;
 					}
 				}

--- a/includes/class-wcsg-checkout.php
+++ b/includes/class-wcsg-checkout.php
@@ -129,7 +129,7 @@ class WCSG_Checkout {
 			$subscription = wcs_get_subscription( $item['subscription_renewal']['subscription_id'] );
 
 			if ( isset( $subscription->recipient_user ) ) {
-				wc_print_notice( esc_html__( 'Shipping to the gift recipient.', 'woocommerce-subscriptions-gifting' ), 'notice' );
+				wc_print_notice( esc_html__( 'Shipping to the subscription recipient.', 'woocommerce-subscriptions-gifting' ), 'notice' );
 				$ship_to_different_address = true;
 			}
 		}

--- a/includes/class-wcsg-download-handler.php
+++ b/includes/class-wcsg-download-handler.php
@@ -8,7 +8,7 @@ class WCSG_Download_Handler {
 	* Setup hooks & filters, when the class is initialised.
 	*/
 	public static function init() {
-		add_filter( 'woocommerce_subscription_settings', __CLASS__ . '::register_download_settings' );
+		add_filter( 'woocommerce_subscription_settings', __CLASS__ . '::register_download_settings', 11, 1 );
 		add_filter( 'woocommerce_downloadable_file_permission_data', __CLASS__ . '::grant_recipient_download_permissions', 11 );
 		add_filter( 'woocommerce_get_item_downloads', __CLASS__ . '::get_item_download_links', 15, 3 );
 
@@ -67,7 +67,7 @@ class WCSG_Download_Handler {
 
 		if ( wcs_is_subscription( $subscription ) && isset( $subscription->recipient_user ) ) {
 
-			$can_purchaser_download = ( 'yes' == get_option( 'woocommerce_subscriptions_gifting_downloadable_products', 'no' ) ) ? true : false;
+			$can_purchaser_download = ( 'yes' == get_option( WCSG_Admin::$option_prefix . '_downloadable_products', 'no' ) ) ? true : false;
 
 			if ( $can_purchaser_download ) {
 				remove_filter( 'woocommerce_downloadable_file_permission_data', __CLASS__ . '::grant_recipient_download_permissions', 11 );
@@ -86,30 +86,32 @@ class WCSG_Download_Handler {
 	}
 
 	/**
-	 * Adds additional gifting specific settings into Subscriptions settings
+	 * Insert Gifting download specific settings into Subscription settings
 	 *
 	 * @param array $settings Subscription's current set of settings.
 	 * @return array $settings new settings with appended wcsg specific settings.
 	 */
 	public static function register_download_settings( $settings ) {
-		$download_settings = array(
-		array(
-			'name'     => __( 'Gifting Subscriptions', 'woocommerce-subscriptions-gifting' ),
-			'type'     => 'title',
-			'id'       => 'woocommerce_subscriptions_gifting',
-		),
-		array(
-			'name'     => __( 'Downloadable Products', 'woocommerce-subscriptions-gifting' ),
-			'desc'     => __( 'Allow both purchaser and recipient to download subscription products.', 'woocommerce-subscriptions-gifting' ),
-			'id'       => 'woocommerce_subscriptions_gifting_downloadable_products',
-			'default'  => 'no',
-			'type'     => 'checkbox',
-			'desc_tip' => __( 'If you want both the recipient and purchaser of a subscription to have access to downloadable products.', 'woocommerce-subscriptions-gifting' ),
-		),
-		array( 'type' => 'sectionend', 'id' => 'woocommerce_subscriptions_gifting' ),
+
+		$insert_index = array_search( array(
+			'type' => 'sectionend',
+			'id'   => WCSG_Admin::$option_prefix,
+			), $settings
 		);
 
-		return array_merge( $settings, $download_settings );
+		array_splice( $settings, $insert_index, 0, array(
+			array(
+				'name'     => __( 'Downloadable Products', 'woocommerce-subscriptions-gifting' ),
+				'desc'     => __( 'Allow both purchaser and recipient to download subscription products.', 'woocommerce-subscriptions-gifting' ),
+				'id'       => WCSG_Admin::$option_prefix . '_downloadable_products',
+				'default'  => 'no',
+				'type'     => 'checkbox',
+				'desc_tip' => __( 'If you want both the recipient and purchaser of a subscription to have access to downloadable products.', 'woocommerce-subscriptions-gifting' ),
+				),
+			)
+		);
+
+		return $settings;
 	}
 
 	/**

--- a/includes/class-wcsg-download-handler.php
+++ b/includes/class-wcsg-download-handler.php
@@ -86,7 +86,7 @@ class WCSG_Download_Handler {
 	}
 
 	/**
-	 * Insert Gifting download specific settings into Subscription settings
+	 * Insert Gifting download specific settings into Subscriptions settings
 	 *
 	 * @param array $settings Subscription's current set of settings.
 	 * @return array $settings new settings with appended wcsg specific settings.

--- a/includes/class-wcsg-product.php
+++ b/includes/class-wcsg-product.php
@@ -22,23 +22,24 @@ class WCSG_Product {
 	 * @return cart_item_data
 	 */
 	public static function add_recipient_data( $cart_item_data ) {
+
 		if ( isset( $_POST['recipient_email'] ) && ! empty( $_POST['recipient_email'][0] ) ) {
 			if ( ! empty( $_POST['_wcsgnonce'] ) && wp_verify_nonce( $_POST['_wcsgnonce'], 'wcsg_add_recipient' ) ) {
-				$recipient_email = sanitize_email( $_POST['recipient_email'][0] );
 
-				if ( $recipient_email == $_POST['recipient_email'][0] && is_email( $recipient_email ) ) {
-					if ( WCS_Gifting::email_belongs_to_current_user( $recipient_email ) ) {
-						throw new Exception( __( 'You cannot gift a product to yourself.', 'woocommerce-subscriptions-gifting' ) );
-					} else {
-						$cart_item_data['wcsg_gift_recipients_email'] = $recipient_email;
-					}
+				if ( WCS_Gifting::validate_recipient_emails( $_POST['recipient_email'] ) ) {
+
+					$cart_item_data['wcsg_gift_recipients_email'] = sanitize_email( $_POST['recipient_email'][0] );
+
 				} else {
-					throw new Exception( __( 'Invalid email address.', 'woocommerce-subscriptions-gifting' ) );
+					// throw exception to be caught by WC add_to_cart(). validate_recipient_emails() will have added the relevant notices
+					throw new Exception();
 				}
+
 			} else {
 				throw new Exception( __( 'There was an error with your request. Please try again..', 'woocommerce-subscriptions-gifting' ) );
 			}
 		}
+
 		return $cart_item_data;
 	}
 

--- a/includes/class-wcsg-product.php
+++ b/includes/class-wcsg-product.php
@@ -34,7 +34,6 @@ class WCSG_Product {
 					// throw exception to be caught by WC add_to_cart(). validate_recipient_emails() will have added the relevant notices
 					throw new Exception();
 				}
-
 			} else {
 				throw new Exception( __( 'There was an error with your request. Please try again..', 'woocommerce-subscriptions-gifting' ) );
 			}

--- a/includes/class-wcsg-recipient-addresses.php
+++ b/includes/class-wcsg-recipient-addresses.php
@@ -60,10 +60,10 @@ class WCSG_Recipient_Addresses {
 
 			switch ( get_query_var( 'edit-address' ) ) {
 				case 'shipping':
-					$field = substr_replace( $field, '<small>' . sprintf( esc_html__( '%sNote:%s This will not update the shipping address of subscriptions you have gifted.', 'woocommerce-subscriptions-gifting' ), '<strong>', '</strong>' ) . '</small>', strpos( $field,'</p>' ), 0 );
+					$field = substr_replace( $field, '<small>' . sprintf( esc_html__( '%sNote:%s This will not update the shipping address of subscriptions you have purchased for others.', 'woocommerce-subscriptions-gifting' ), '<strong>', '</strong>' ) . '</small>', strpos( $field,'</p>' ), 0 );
 					break;
 				case 'billing':
-					$field = substr_replace( $field, '<small>' . sprintf( esc_html__( '%sNote:%s This will not update the billing address of subscriptions gifted to you.', 'woocommerce-subscriptions-gifting' ), '<strong>', '</strong>' ) . '</small>', strpos( $field,'</p>' ), 0 );
+					$field = substr_replace( $field, '<small>' . sprintf( esc_html__( '%sNote:%s This will not update the billing address of subscriptions purchased for you.', 'woocommerce-subscriptions-gifting' ), '<strong>', '</strong>' ) . '</small>', strpos( $field,'</p>' ), 0 );
 					break;
 			}
 		}

--- a/includes/class-wcsg-recipient-addresses.php
+++ b/includes/class-wcsg-recipient-addresses.php
@@ -63,7 +63,7 @@ class WCSG_Recipient_Addresses {
 					$field = substr_replace( $field, '<small>' . sprintf( esc_html__( '%sNote:%s This will not update the shipping address of subscriptions you have purchased for others.', 'woocommerce-subscriptions-gifting' ), '<strong>', '</strong>' ) . '</small>', strpos( $field,'</p>' ), 0 );
 					break;
 				case 'billing':
-					$field = substr_replace( $field, '<small>' . sprintf( esc_html__( '%sNote:%s This will not update the billing address of subscriptions purchased for you.', 'woocommerce-subscriptions-gifting' ), '<strong>', '</strong>' ) . '</small>', strpos( $field,'</p>' ), 0 );
+					$field = substr_replace( $field, '<small>' . sprintf( esc_html__( '%sNote:%s This will not update the billing address of subscriptions purchased for you by someone else.', 'woocommerce-subscriptions-gifting' ), '<strong>', '</strong>' ) . '</small>', strpos( $field,'</p>' ), 0 );
 					break;
 			}
 		}

--- a/templates/html-add-recipient.php
+++ b/templates/html-add-recipient.php
@@ -1,6 +1,6 @@
 <fieldset>
 	<input type="checkbox" id="gifting_<?php esc_attr_e( $id, 'woocommerce_subscriptions_gifting' ) ?>_option" class="woocommerce_subscription_gifting_checkbox" value="gift" <?php esc_attr_e( ( empty( $email ) ) ? '' : 'checked', 'woocommerce_subscriptions_gifting' ) ?> />
-	<?php echo esc_html( apply_filters( 'wcsg_enable_gifting_checkbox_label', __( get_option( WCSG_Admin::$option_prefix . '_gifting_checkbox_text', 'This is a gift' ), 'woocommerce_subscriptions_gifting' ) ) ); ?> <br />
+	<?php echo esc_html( apply_filters( 'wcsg_enable_gifting_checkbox_label', get_option( WCSG_Admin::$option_prefix . '_gifting_checkbox_text', __( 'This is a gift', 'woocommerce_subscriptions_gifting' ) ) ) ); ?> <br />
 	<p class="form-row form-row <?php esc_attr_e( implode( ' ', $email_field_args['class'] ) ); ?>" style="<?php esc_attr_e( implode( '; ', $email_field_args['style_attributes'] ) );?>">
 		<label for="recipient_email[<?php esc_attr_e( $id );?>]">
 			<?php esc_html_e( "Recipient's Email Address:", 'woocommerce-subscriptions-gifting' ); ?>

--- a/templates/html-add-recipient.php
+++ b/templates/html-add-recipient.php
@@ -1,6 +1,6 @@
 <fieldset>
 	<input type="checkbox" id="gifting_<?php esc_attr_e( $id, 'woocommerce_subscriptions_gifting' ) ?>_option" class="woocommerce_subscription_gifting_checkbox" value="gift" <?php esc_attr_e( ( empty( $email ) ) ? '' : 'checked', 'woocommerce_subscriptions_gifting' ) ?> />
-	<?php echo esc_html( apply_filters( 'wcsg_enable_gifting_checkbox_label', __( 'This is a gift', 'woocommerce_subscriptions_gifting' ) ) ); ?> <br />
+	<?php echo esc_html( apply_filters( 'wcsg_enable_gifting_checkbox_label', __( get_option( WCSG_Admin::$option_prefix . '_gifting_checkbox_text', 'This is a gift' ), 'woocommerce_subscriptions_gifting' ) ) ); ?> <br />
 	<p class="form-row form-row <?php esc_attr_e( implode( ' ', $email_field_args['class'] ) ); ?>" style="<?php esc_attr_e( implode( '; ', $email_field_args['style_attributes'] ) );?>">
 		<label for="recipient_email[<?php esc_attr_e( $id );?>]">
 			<?php esc_html_e( "Recipient's Email Address:", 'woocommerce-subscriptions-gifting' ); ?>

--- a/woocommerce-subscriptions-gifting.php
+++ b/woocommerce-subscriptions-gifting.php
@@ -170,7 +170,7 @@ class WCS_Gifting {
 				$cleaned_recipient = sanitize_email( $recipient );
 				if ( $recipient == $cleaned_recipient && is_email( $cleaned_recipient ) ) {
 					if ( ! $self_gifting_found && self::email_belongs_to_current_user( $cleaned_recipient ) ) {
-						wc_add_notice( __( 'You cannot gift a product to yourself.', 'woocommerce-subscriptions-gifting' ), 'error' );
+						wc_add_notice( __( 'Please enter a recipient other than yourself.', 'woocommerce-subscriptions-gifting' ), 'error' );
 						$self_gifting_found = true;
 					}
 				} else if ( ! empty( $recipient ) && ! $invalid_email_found ) {

--- a/woocommerce-subscriptions-gifting.php
+++ b/woocommerce-subscriptions-gifting.php
@@ -170,7 +170,7 @@ class WCS_Gifting {
 				$cleaned_recipient = sanitize_email( $recipient );
 				if ( $recipient == $cleaned_recipient && is_email( $cleaned_recipient ) ) {
 					if ( ! $self_gifting_found && self::email_belongs_to_current_user( $cleaned_recipient ) ) {
-						wc_add_notice( __( 'Please enter a recipient other than yourself.', 'woocommerce-subscriptions-gifting' ), 'error' );
+						wc_add_notice( __( 'Please enter someone else\'s email address.', 'woocommerce-subscriptions-gifting' ), 'error' );
 						$self_gifting_found = true;
 					}
 				} else if ( ! empty( $recipient ) && ! $invalid_email_found ) {


### PR DESCRIPTION
This PR includes various changes for supporting stores using Gifting for corporate purchasing.

- Adds a setting allowing store owners to edit the "This is a gift" text displayed on the single product, cart and checkout pages (https://cloudup.com/cM9F2sNRGGe)
- Rephrase user-facing strings which reference the word 'gift', using a more generic term like recipient: 
 - The error notice displayed when the customer tries to add products to a gifted subscription renewal cart. (https://cloudup.com/cyAkGtIUirW) 
 - The notice explaining that we've loaded the recipient's shipping address into the checkout when manually paying for a gifted subscription renewal order. (https://cloudup.com/cJJJdi7qJzk)
 - notes displayed when a customer updates their: 
   - billing address (https://cloudup.com/c6RAp9NkK-P)
    - shipping address (https://cloudup.com/chuymk8Y4yV)
 - The error notice displayed when the customer attempts to enter a recipient email address which belongs to their account - effectively self-gifting (https://cloudup.com/caJj820l8U5)

I also snuck in changes which tidy up duplicated code when validating recipient emails on the single product page.

fixes #135 