### PR TITLE
Revert fix to query vars

### DIFF
--- a/includes/class-wcsg-query.php
+++ b/includes/class-wcsg-query.php
@@ -30,11 +30,13 @@ class WCSG_Query extends WC_Query {
 	 */
 	public function get_endpoint_title( $title ) {
 		global $wp;
-		// Enqueue woocommerce country select scripts
-		wp_enqueue_script( 'wc-country-select' );
-		wp_enqueue_script( 'wc-address-i18n' );
+
 		if ( is_main_query() && in_the_loop() && is_page() && isset( $wp->query_vars['new-recipient-account'] ) ) {
 			$title = __( 'Account Details', 'woocommerce-subscriptions-gifting' );
+
+			// Enqueue WooCommerce country select scripts
+			wp_enqueue_script( 'wc-country-select' );
+			wp_enqueue_script( 'wc-address-i18n' );
 		}
 
 		return $title;

--- a/includes/class-wcsg-query.php
+++ b/includes/class-wcsg-query.php
@@ -17,7 +17,9 @@ class WCSG_Query extends WC_Query {
 	 * Init query vars by loading options.
 	 */
 	public function init_query_vars() {
-		WC()->query->query_vars['new-recipient-account'] = get_option( 'woocommerce_myaccount_new_recipient_account_endpoint', 'new-recipient-account' );
+		$this->query_vars = array(
+			'new-recipient-account' => get_option( 'woocommerce_myaccount_view_subscriptions_endpoint', 'new-recipient-account' ),
+		);
 	}
 
 	/**

--- a/woocommerce-subscriptions-gifting.php
+++ b/woocommerce-subscriptions-gifting.php
@@ -84,7 +84,8 @@ class WCS_Gifting {
 
 		add_action( 'wp_enqueue_scripts', __CLASS__ . '::gifting_scripts' );
 
-		add_action( 'plugins_loaded', __CLASS__ . '::load_dependant_classes' );
+		// Needs to run after Subscriptions has loaded its dependant classes
+		add_action( 'plugins_loaded', __CLASS__ . '::load_dependant_classes' , 11 );
 
 		add_action( 'init', __CLASS__ . '::maybe_flush_rewrite_rules' );
 


### PR DESCRIPTION
Revert the change introduced in https://github.com/Prospress/woocommerce-subscriptions-gifting/pull/105 inline with the revert of the same change in Subscriptions (https://github.com/Prospress/woocommerce-subscriptions/pull/1286).

This PR also introduces the exact same function of the same name from https://github.com/Prospress/woocommerce-subscriptions/pull/1286/commits/2753b93fb90e174f00bc4b0749b5077991e8a375. If there are any ideas on how Gifting could use the same functionality of `WCS_Query::pre_get_posts` without the need to duplicate the function let me know 😄. 

Also did some tidying up so the scripts loaded for the new recipient account details page aren't loaded on every page. 😆  