### PR TITLE
fix cart form submit by enter press after entering recipient email [WC 2.6]

### DIFF
--- a/js/wcs-gifting.js
+++ b/js/wcs-gifting.js
@@ -7,4 +7,20 @@ jQuery(document).ready(function($){
 			$(this).parent().find('.recipient_email').val('');
 		}
 	});
+
+	$(document).on('submit', 'div.woocommerce > form', function(evt) {
+
+		var $form = $( evt.target );
+		var $submit = $( document.activeElement );
+
+		// if we're not on the cart page exit
+		if ( 0 === $form.find( 'table.shop_table.cart' ).length ) {
+			return;
+		}
+
+		// if the recipient email element is the active element, the clicked button is the update cart button
+		if ( $submit.is( 'input.recipient_email' ) ) {
+			 $( 'input[type=submit][name=update_cart]').attr( 'clicked', 'true' );
+		}
+	});
 });


### PR DESCRIPTION
When submitting the cart form where the active element is a recipient email field, ensure the clicked submit button is the `update_cart` rather than the default `apply_coupon`.

To replicate on `master` 

1. add a subscription product to the cart
2. go to the cart page
3. enter a recipient email address and press enter

You should receive the ['Please enter a coupon code'](https://cloudup.com/cXm8GOseaxl) message

fixes #150