### PR TITLE
Check the screen ID property exists before trying to access it

### DIFF
--- a/includes/class-wcsg-admin.php
+++ b/includes/class-wcsg-admin.php
@@ -67,7 +67,7 @@ class WCSG_Admin {
 		if ( is_admin() ) {
 			$screen = get_current_screen();
 
-			if ( 'edit-shop_subscription' == $screen->id ) {
+			if ( isset( $screen->id ) && 'edit-shop_subscription' == $screen->id ) {
 				foreach ( $formatted_meta as $meta_id => $meta ) {
 					if ( 'wcsg_recipient' == $meta['key'] ) {
 						unset( $formatted_meta[ $meta_id ] );


### PR DESCRIPTION
Fixes PHP error notice when triggering a PayPal RT subscription renewal order from action scheduler screen.

To replicate: 
1. Add a subscription product with a recipient to cart.
2. Choose PayPal as the payment method on checkout (must have RT enabled)
3. Go to the admin action scheduler screen (**Tools->Scheduled Actions** from the admin dashboard)
4. Find and run the subscription scheduled payment action. 

At this point you should receive the error:

```
PHP Notice:  Trying to get property of non-object in .../wp-content/plugins/woocommerce-subscriptions-gifting/includes/class-wcsg-admin.php on line 70
```

The line in Subscriptions which triggers this issue is [paypal-reference-transaction-api-request L499](https://github.com/Prospress/woocommerce-subscriptions/blob/563ac8d20d32a1cd9892bea697003d626f9af9a9/includes/gateways/paypal/includes/class-wcs-paypal-reference-transaction-api-request.php#L499). Which is filtered by Gifting's `WCSG_Admin::remove_recipient_order_item_meta()`.