### PR TITLE
Introduce filterable is giftable product function

### DIFF
--- a/includes/class-wcsg-cart.php
+++ b/includes/class-wcsg-cart.php
@@ -124,7 +124,7 @@ class WCSG_Cart {
 	 * @return bool | whether the cart item is giftable.
 	 */
 	public static function is_giftable_item( $cart_item ) {
-		return WC_Subscriptions_Product::is_subscription( $cart_item['data'] ) && ! isset( $cart_item['subscription_renewal'] ) && ! isset( $cart_item['subscription_switch'] );
+		return WCSG_Product::is_giftable( $cart_item['data'] ) && ! isset( $cart_item['subscription_renewal'] ) && ! isset( $cart_item['subscription_switch'] );
 	}
 
 	/**

--- a/includes/class-wcsg-memberships-integration.php
+++ b/includes/class-wcsg-memberships-integration.php
@@ -34,7 +34,7 @@ class WCSG_Memberships_Integration {
 	 */
 	public static function grant_membership_access( $grant_access, $membership_data ) {
 
-		if ( $grant_access && WC_Subscriptions_Product::is_subscription( $membership_data['product_id'] ) && WCS_Gifting::order_contains_gifted_subscription( $membership_data['order_id'] ) ) {
+		if ( $grant_access && WCSG_Product::is_giftable( $membership_data['product_id'] ) && WCS_Gifting::order_contains_gifted_subscription( $membership_data['order_id'] ) ) {
 
 			// defaulted to false unless we find the purchaser has purchased the product for themselves
 			$grant_access = false;

--- a/includes/class-wcsg-product.php
+++ b/includes/class-wcsg-product.php
@@ -62,13 +62,28 @@ class WCSG_Product {
 	 */
 	public static function add_gifting_option_product() {
 		global $product;
-		if ( WC_Subscriptions_Product::is_subscription( $product ) && ! isset( $_GET['switch-subscription'] ) ) {
+		if ( self::is_giftable( $product ) && ! isset( $_GET['switch-subscription'] ) ) {
 			$email = '';
 			if ( ! empty( $_POST['recipient_email'][0] ) && ! empty( $_POST['_wcsgnonce'] ) && wp_verify_nonce( $_POST['_wcsgnonce'], 'wcsg_add_recipient' ) ) {
 				$email = $_POST['recipient_email'][0];
 			}
 			wc_get_template( 'html-add-recipient.php', array( 'email_field_args' => WCS_Gifting::get_recipient_email_field_args( $email ), 'id' => 0, 'email' => $email ), '', plugin_dir_path( WCS_Gifting::$plugin_file ) . 'templates/' );
 		}
+	}
+
+	/**
+	 * Checks if a given product is a giftable product
+	 *
+	 * @param int|WC_Product $product A WC_Product object or the ID of a product to check
+	 * @return bool
+	 */
+	public static function is_giftable( $product ) {
+
+		if ( ! is_object( $product ) ) {
+			$product = wc_get_product( $product );
+		}
+
+		return apply_filters( 'wcsg_is_giftable_product', WC_Subscriptions_Product::is_subscription( $product ), $product );
 	}
 }
 WCSG_Product::init();


### PR DESCRIPTION
see #155 for background.

This PR replaces all uses of `WC_Subscriptions_Product::is_subscription()` with a filterable function, allowing 3rd parties to enable/disable gifting for a specific product.

fixes #155