### PR TITLE
Add license info

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # WooCommerce Subscriptions Gifting
 
 [![Build Status](https://travis-ci.org/Prospress/woocommerce-subscriptions-gifting.svg?branch=master)](https://travis-ci.org/Prospress/woocommerce-subscriptions-gifting) [![codecov.io](http://codecov.io/github/Prospress/woocommerce-subscriptions-gifting/coverage.svg?token=d9aaaF18bY&branch=master)](http://codecov.io/github/Prospress/woocommerce-subscriptions-gifting?branch=master)
+[![license: GPL v2](https://img.shields.io/badge/license-GPLv2-blue.svg)](http://opensource.org/licenses/GPL-2.0)
 
 [WooCommerce Subscriptions](https://www.woothemes.com/products/woocommerce-subscriptions/) makes it possible to offer subscription products in your WooCommerce store.
 

--- a/woocommerce-subscriptions-gifting.php
+++ b/woocommerce-subscriptions-gifting.php
@@ -6,6 +6,7 @@
  * Author: Prospress Inc.
  * Author URI: http://prospress.com/
  * Version: 1.0
+ * License: GPLv2
  *
  * GitHub Plugin URI: Prospress/woocommerce-subscriptions-gifting
  * GitHub Branch: master


### PR DESCRIPTION
Tiny edit to the Plugin file header and README file to add a GPLv2 license.

Uses [shields.io](http://shields.io/). Lots of services include Travis etc. that use the [same standard](https://github.com/badges/shields#services-using-the-shields-standard)

Similar reasoning to https://github.com/Prospress/woocommerce-subscriptions-importer-exporter/pull/135