### PR TITLE
Coding standard fixes

### DIFF
--- a/includes/class-wcsg-admin.php
+++ b/includes/class-wcsg-admin.php
@@ -104,7 +104,7 @@ class WCSG_Admin {
 				'desc_tip' => true,
 			),
 			array( 'type' => 'sectionend', 'id' => self::$option_prefix ),
-		 ) );
+		) );
 	}
 
 	/**

--- a/includes/class-wcsg-cart.php
+++ b/includes/class-wcsg-cart.php
@@ -90,10 +90,7 @@ class WCSG_Cart {
 	 * @param string $email The email of the gift recipient.
 	 */
 	public static function generate_static_gifting_html( $cart_item_key, $email ) {
-
-		return '<fieldset id="woocommerce_subscriptions_gifting_field">'
-		     . '<label class="woocommerce_subscriptions_gifting_recipient_email">' . esc_html__( 'Recipient: ', 'woocommerce-subscriptions-gifting' ) . '</label>' . esc_html( $email )
-		     . '</fieldset>';
+		return '<fieldset id="woocommerce_subscriptions_gifting_field"><label class="woocommerce_subscriptions_gifting_recipient_email">' . esc_html__( 'Recipient: ', 'woocommerce-subscriptions-gifting' ) . '</label>' . esc_html( $email ) . '</fieldset>';
 	}
 
 	/**

--- a/includes/class-wcsg-checkout.php
+++ b/includes/class-wcsg-checkout.php
@@ -71,7 +71,7 @@ class WCSG_Checkout {
 					'city'       => get_user_meta( $recipient_user_id, 'shipping_city', true ),
 					'state'      => get_user_meta( $recipient_user_id, 'shipping_state', true ),
 					'postcode'   => get_user_meta( $recipient_user_id, 'shipping_postcode', true ),
-					), 'shipping' );
+				), 'shipping' );
 			}
 		}
 	}

--- a/includes/class-wcsg-download-handler.php
+++ b/includes/class-wcsg-download-handler.php
@@ -242,7 +242,7 @@ class WCSG_Download_Handler {
 
 		return $wpdb->get_results( $wpdb->prepare( "
 			SELECT * FROM {$wpdb->prefix}woocommerce_downloadable_product_permissions
-			WHERE order_id = %d ORDER BY {$order_by}", $subscription_id ) );
+			WHERE order_id = %d ORDER BY %s", $subscription_id, $order_by ) );
 	}
 
 	/**

--- a/includes/class-wcsg-recipient-addresses.php
+++ b/includes/class-wcsg-recipient-addresses.php
@@ -60,10 +60,10 @@ class WCSG_Recipient_Addresses {
 
 			switch ( get_query_var( 'edit-address' ) ) {
 				case 'shipping':
-					$field = substr_replace( $field, '<small>' . sprintf( esc_html__( '%sNote:%s This will not update the shipping address of subscriptions you have purchased for others.', 'woocommerce-subscriptions-gifting' ), '<strong>', '</strong>' ) . '</small>', strpos( $field,'</p>' ), 0 );
+					$field = substr_replace( $field, '<small>' . sprintf( esc_html__( '%1$sNote:%2$s This will not update the shipping address of subscriptions you have purchased for others.', 'woocommerce-subscriptions-gifting' ), '<strong>', '</strong>' ) . '</small>', strpos( $field,'</p>' ), 0 );
 					break;
 				case 'billing':
-					$field = substr_replace( $field, '<small>' . sprintf( esc_html__( '%sNote:%s This will not update the billing address of subscriptions purchased for you by someone else.', 'woocommerce-subscriptions-gifting' ), '<strong>', '</strong>' ) . '</small>', strpos( $field,'</p>' ), 0 );
+					$field = substr_replace( $field, '<small>' . sprintf( esc_html__( '%1$sNote:%2$s This will not update the billing address of subscriptions purchased for you by someone else.', 'woocommerce-subscriptions-gifting' ), '<strong>', '</strong>' ) . '</small>', strpos( $field,'</p>' ), 0 );
 					break;
 			}
 		}

--- a/includes/class-wcsg-recipient-details.php
+++ b/includes/class-wcsg-recipient-details.php
@@ -88,7 +88,7 @@ class WCSG_Recipient_Details {
 						if ( isset( $_POST['set_billing'] ) ) {
 							update_user_meta( $user->ID, str_replace( 'shipping', 'billing', $key ), wc_clean( $_POST[ $key ] ) );
 						}
-						$address[ str_replace( 'shipping' . '_', '', $key ) ] = wc_clean( $_POST[ $key ] );
+						$address[ str_replace( 'shipping_', '', $key ) ] = wc_clean( $_POST[ $key ] );
 					}
 				}
 				$user->user_pass = wc_clean( $_POST['new_password'] );

--- a/includes/class-wcsg-recipient-management.php
+++ b/includes/class-wcsg-recipient-management.php
@@ -459,7 +459,7 @@ class WCSG_Recipient_Management {
 					foreach ( $subscriptions as $subscription_id ) {
 
 						$subscription = wcs_get_subscription( $subscription_id );
-						echo '<dd>' . esc_html__( 'Subscription' , 'woocommerce-subscriptions-gifting' ) . ' <a href="'. esc_url( wcs_get_edit_post_link( $subscription->id ) ) . '">#' . esc_html( $subscription->get_order_number() ) . '</a></dd>';
+						echo '<dd>' . esc_html__( 'Subscription' , 'woocommerce-subscriptions-gifting' ) . ' <a href="' . esc_url( wcs_get_edit_post_link( $subscription->id ) ) . '">#' . esc_html( $subscription->get_order_number() ) . '</a></dd>';
 
 					}
 				}

--- a/includes/class-wcsg-recipient-management.php
+++ b/includes/class-wcsg-recipient-management.php
@@ -80,7 +80,7 @@ class WCSG_Recipient_Management {
 	 */
 	public static function add_recipient_actions( $actions, $subscription ) {
 
-		if ( WCS_Gifting::is_gifted_subscription( $subscription ) && $subscription->recipient_user == wp_get_current_user()->ID ) {
+		if ( WCS_Gifting::is_gifted_subscription( $subscription ) && wp_get_current_user()->ID == $subscription->recipient_user ) {
 
 			$recipient_actions = array();
 			$current_status    = $subscription->get_status();
@@ -159,7 +159,7 @@ class WCSG_Recipient_Management {
 	 */
 	public static function recipient_can_suspend( $user_can_suspend, $subscription ) {
 
-		if ( WCS_Gifting::is_gifted_subscription( $subscription ) && $subscription->recipient_user == wp_get_current_user()->ID ) {
+		if ( WCS_Gifting::is_gifted_subscription( $subscription ) && wp_get_current_user()->ID == $subscription->recipient_user ) {
 
 			// Make sure subscription suspension count hasn't been reached
 			$suspension_count    = $subscription->suspension_count;

--- a/includes/emails/class-wcsg-email-completed-renewal-order.php
+++ b/includes/emails/class-wcsg-email-completed-renewal-order.php
@@ -11,7 +11,7 @@ class WCSG_Email_Completed_Renewal_Order extends WCS_Email_Completed_Renewal_Ord
 
 		$this->id             = 'recipient_completed_renewal_order';
 		$this->title          = __( 'Completed Renewal Order - Recipient', 'woocommerce-subscriptions-gifting' );
-		$this->description    = __( 'Renewal order complete emails are sent to the recipient when a subscription renewal order is marked complete and usually indicates that the item for that renewal period has been shipped.', 'woocommerce-subscriptions-gifting' );;
+		$this->description    = __( 'Renewal order complete emails are sent to the recipient when a subscription renewal order is marked complete and usually indicates that the item for that renewal period has been shipped.', 'woocommerce-subscriptions-gifting' );
 		$this->customer_email = true;
 
 		$this->heading        = __( 'Your renewal order is complete', 'woocommerce-subscriptions-gifting' );

--- a/templates/emails/new-recipient-customer.php
+++ b/templates/emails/new-recipient-customer.php
@@ -14,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 <?php do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 
 <p><?php printf( esc_html__( 'Hi there,', 'woocommerce-subscriptions-gifting' ) ); ?></p>
-<p><?php printf( esc_html__( '%s just purchased a subscription for you at %s so we\'ve created an account for you to manage the subscription.', 'woocommerce-subscriptions-gifting' ), wp_kses( $subscription_purchaser, wp_kses_allowed_html( 'user_description' ) ), esc_html( $blogname ) ); ?></p>
+<p><?php printf( esc_html__( '%1$s just purchased a subscription for you at %2$s so we\'ve created an account for you to manage the subscription.', 'woocommerce-subscriptions-gifting' ), wp_kses( $subscription_purchaser, wp_kses_allowed_html( 'user_description' ) ), esc_html( $blogname ) ); ?></p>
 
 <p><?php printf( esc_html__( 'Your username is: %s', 'woocommerce-subscriptions-gifting' ), '<strong>' . esc_html( $user_login ) . '</strong>' ); ?></p>
 <p><?php printf( esc_html__( 'Your password has been automatically generated: %s', 'woocommerce-subscriptions-gifting' ), '<strong>' . esc_html( $user_password ) . '</strong>' ); ?></p>

--- a/templates/emails/plain/new-recipient-customer.php
+++ b/templates/emails/plain/new-recipient-customer.php
@@ -12,7 +12,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 echo '= ' . $email_heading . " =\n\n";
 
 echo sprintf( __( 'Hi there,', 'woocommerce-subscriptions-gifting' ) ) . "\n\n";
-echo sprintf( __( '%s just purchased a subscription for you at %s so we\'ve created an account for you to manage the subscription.', 'woocommerce-subscriptions-gifting' ), esc_html( $subscription_purchaser ), esc_html( $blogname ) ) . "\n\n";
+echo sprintf( __( '%1$s just purchased a subscription for you at %2$s so we\'ve created an account for you to manage the subscription.', 'woocommerce-subscriptions-gifting' ), esc_html( $subscription_purchaser ), esc_html( $blogname ) ) . "\n\n";
 
 echo sprintf( __( 'Your username is: %s', 'woocommerce-subscriptions-gifting' ), esc_html( $user_login ) ) . "\n";
 echo sprintf( __( 'Your password has been automatically generated: %s', 'woocommerce-subscriptions-gifting' ), esc_html( $user_password ) ) . "\n\n";

--- a/templates/emails/plain/recipient-new-initial-order.php
+++ b/templates/emails/plain/recipient-new-initial-order.php
@@ -11,15 +11,15 @@ if ( ! defined( 'ABSPATH' ) ) {
 echo '= ' . $email_heading . " =\n\n";
 echo sprintf( __( 'Hi there,', 'woocommerce-subscriptions-gifting' ) ) . "\n";
 // translators: 1$: Purchaser's name and email, 2$ The name of the site.
-echo sprintf( __( '%1$s just purchased ' . _n( 'a subscription', 'subscriptions', count( $subscriptions ), 'woocommerce-subscriptions-gifting' ) . ' for you at %2$s.', 'woocommerce-subscriptions-gifting' ), wp_kses( $subscription_purchaser, wp_kses_allowed_html( 'user_description' ) ), esc_html( $blogname ) );
-echo sprintf( __( ' Details of the ' . _n( 'subscription', 'subscriptions', count( $subscriptions ), 'woocommerce-subscriptions-gifting' ) . ' are shown below.', 'woocommerce-subscriptions-gifting' ) ) . "\n\n";
+echo sprintf( __( '%1$s just purchased %2$s for you at %3$s.', 'woocommerce-subscriptions-gifting' ), wp_kses( $subscription_purchaser, wp_kses_allowed_html( 'user_description' ) ), _n( 'a subscription', 'subscriptions', count( $subscriptions ), 'woocommerce-subscriptions-gifting' ), esc_html( $blogname ) );
+echo sprintf( __( ' Details of the %s are shown below.', 'woocommerce-subscriptions-gifting' ), _n( 'subscription', 'subscriptions', count( $subscriptions ), 'woocommerce-subscriptions-gifting' ) ) . "\n\n";
 
 $new_recipient = get_user_meta( $recipient_user->ID, 'wcsg_update_account', true );
 
 if ( 'true' == $new_recipient ) {
 	echo esc_html__( 'We noticed you didn\'t have an account so we created one for you. Your account login details will have been sent to you in a separate email.' ) . "\n\n";
 } else {
-	echo sprintf( __( 'You may access your account area to view your new ' . _n( 'subscription', 'subscriptions', count( $subscriptions ), 'woocommerce-subscriptions-gifting' ) . ' here: %s.', 'woocommerce-subscriptions-gifting' ), esc_url( wc_get_page_permalink( 'myaccount' ) ) ) . "\n\n";
+	echo sprintf( __( 'You may access your account area to view your new %1$s here: %2$s.', 'woocommerce-subscriptions-gifting' ), _n( 'subscription', 'subscriptions', count( $subscriptions ), 'woocommerce-subscriptions-gifting' ), esc_url( wc_get_page_permalink( 'myaccount' ) ) ) . "\n\n";
 }
 
 foreach ( $subscriptions as $subscription_id ) {

--- a/templates/emails/plain/recipient-new-initial-order.php
+++ b/templates/emails/plain/recipient-new-initial-order.php
@@ -11,13 +11,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 echo '= ' . $email_heading . " =\n\n";
 echo sprintf( __( 'Hi there,', 'woocommerce-subscriptions-gifting' ) ) . "\n";
 // translators: 1$: Purchaser's name and email, 2$ The name of the site.
-echo sprintf( __( '%1$s just purchased ' .  _n( 'a subscription', 'subscriptions', count( $subscriptions ), 'woocommerce-subscriptions-gifting' ) . ' for you at %2$s.', 'woocommerce-subscriptions-gifting' ), wp_kses( $subscription_purchaser, wp_kses_allowed_html( 'user_description' ) ), esc_html( $blogname ) );
+echo sprintf( __( '%1$s just purchased ' . _n( 'a subscription', 'subscriptions', count( $subscriptions ), 'woocommerce-subscriptions-gifting' ) . ' for you at %2$s.', 'woocommerce-subscriptions-gifting' ), wp_kses( $subscription_purchaser, wp_kses_allowed_html( 'user_description' ) ), esc_html( $blogname ) );
 echo sprintf( __( ' Details of the ' . _n( 'subscription', 'subscriptions', count( $subscriptions ), 'woocommerce-subscriptions-gifting' ) . ' are shown below.', 'woocommerce-subscriptions-gifting' ) ) . "\n\n";
 
 $new_recipient = get_user_meta( $recipient_user->ID, 'wcsg_update_account', true );
 
 if ( 'true' == $new_recipient ) {
-	echo esc_html__( 'We noticed you didn\'t have an account so we created one for you. Your account login details will have been sent to you in a separate email.' )  . "\n\n";
+	echo esc_html__( 'We noticed you didn\'t have an account so we created one for you. Your account login details will have been sent to you in a separate email.' ) . "\n\n";
 } else {
 	echo sprintf( __( 'You may access your account area to view your new ' . _n( 'subscription', 'subscriptions', count( $subscriptions ), 'woocommerce-subscriptions-gifting' ) . ' here: %s.', 'woocommerce-subscriptions-gifting' ), esc_url( wc_get_page_permalink( 'myaccount' ) ) ) . "\n\n";
 }

--- a/templates/emails/recipient-new-initial-order.php
+++ b/templates/emails/recipient-new-initial-order.php
@@ -14,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 <?php do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 
 <p><?php printf( esc_html__( 'Hi there,', 'woocommerce-subscriptions-gifting' ) ); ?></p>
-<p><?php printf( esc_html__( '%s just purchased ' .  _n( 'a subscription', 'subscriptions', count( $subscriptions ), 'woocommerce-subscriptions-gifting' ) . ' for you at %s.', 'woocommerce-subscriptions-gifting' ), wp_kses( $subscription_purchaser, wp_kses_allowed_html( 'user_description' ) ), esc_html( $blogname ) ); ?>
+<p><?php printf( esc_html__( '%s just purchased ' . _n( 'a subscription', 'subscriptions', count( $subscriptions ), 'woocommerce-subscriptions-gifting' ) . ' for you at %s.', 'woocommerce-subscriptions-gifting' ), wp_kses( $subscription_purchaser, wp_kses_allowed_html( 'user_description' ) ), esc_html( $blogname ) ); ?>
 <?php printf( esc_html__( ' Details of the ' . _n( 'subscription', 'subscriptions', count( $subscriptions ), 'woocommerce-subscriptions-gifting' ) . ' are shown below.', 'woocommerce-subscriptions-gifting' ) ); ?>
 </p>
 <?php
@@ -28,7 +28,7 @@ if ( 'true' == $new_recipient ) : ?>
 <?php else : ?>
 
 <p><?php printf( esc_html__( 'You may access your account area to view your new ' . _n( 'subscription', 'subscriptions', count( $subscriptions ), 'woocommerce-subscriptions-gifting' ) . ' here: %1$sMy Account%2$s.', 'woocommerce-subscriptions-gifting' ),
-	'<a href="' . esc_url( wc_get_page_permalink( 'myaccount' ) )  . '">',
+	'<a href="' . esc_url( wc_get_page_permalink( 'myaccount' ) ) . '">',
 	'</a>'
 ); ?></p>
 

--- a/templates/emails/recipient-new-initial-order.php
+++ b/templates/emails/recipient-new-initial-order.php
@@ -14,8 +14,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 <?php do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 
 <p><?php printf( esc_html__( 'Hi there,', 'woocommerce-subscriptions-gifting' ) ); ?></p>
-<p><?php printf( esc_html__( '%s just purchased ' . _n( 'a subscription', 'subscriptions', count( $subscriptions ), 'woocommerce-subscriptions-gifting' ) . ' for you at %s.', 'woocommerce-subscriptions-gifting' ), wp_kses( $subscription_purchaser, wp_kses_allowed_html( 'user_description' ) ), esc_html( $blogname ) ); ?>
-<?php printf( esc_html__( ' Details of the ' . _n( 'subscription', 'subscriptions', count( $subscriptions ), 'woocommerce-subscriptions-gifting' ) . ' are shown below.', 'woocommerce-subscriptions-gifting' ) ); ?>
+<p><?php printf( esc_html__( '%1$s just purchased %2$s for you at %3$s.', 'woocommerce-subscriptions-gifting' ), wp_kses( $subscription_purchaser, wp_kses_allowed_html( 'user_description' ) ), esc_html( _n( 'a subscription', 'subscriptions', count( $subscriptions ), 'woocommerce-subscriptions-gifting' ) ), esc_html( $blogname ) ); ?>
+<?php printf( esc_html__( ' Details of the %s are shown below.', 'woocommerce-subscriptions-gifting' ), esc_html( _n( 'subscription', 'subscriptions', count( $subscriptions ), 'woocommerce-subscriptions-gifting' ) ) ); ?>
 </p>
 <?php
 
@@ -27,7 +27,8 @@ if ( 'true' == $new_recipient ) : ?>
 
 <?php else : ?>
 
-<p><?php printf( esc_html__( 'You may access your account area to view your new ' . _n( 'subscription', 'subscriptions', count( $subscriptions ), 'woocommerce-subscriptions-gifting' ) . ' here: %1$sMy Account%2$s.', 'woocommerce-subscriptions-gifting' ),
+<p><?php printf( esc_html__( 'You may access your account area to view your new %1$s here: %2$sMy Account%3$s.', 'woocommerce-subscriptions-gifting' ),
+	esc_html( _n( 'subscription', 'subscriptions', count( $subscriptions ), 'woocommerce-subscriptions-gifting' ) ),
 	'<a href="' . esc_url( wc_get_page_permalink( 'myaccount' ) ) . '">',
 	'</a>'
 ); ?></p>

--- a/templates/html-add-recipient.php
+++ b/templates/html-add-recipient.php
@@ -1,11 +1,11 @@
 <fieldset>
-	<input type="checkbox" id="gifting_<?php esc_attr_e( $id, 'woocommerce_subscriptions_gifting' ) ?>_option" class="woocommerce_subscription_gifting_checkbox" value="gift" <?php esc_attr_e( ( empty( $email ) ) ? '' : 'checked', 'woocommerce_subscriptions_gifting' ) ?> />
+	<input type="checkbox" id="gifting_<?php echo esc_attr( $id ); ?>_option" class="woocommerce_subscription_gifting_checkbox" value="gift" <?php echo esc_attr( ( empty( $email ) ) ? '' : 'checked' ); ?> />
 	<?php echo esc_html( apply_filters( 'wcsg_enable_gifting_checkbox_label', get_option( WCSG_Admin::$option_prefix . '_gifting_checkbox_text', __( 'This is a gift', 'woocommerce_subscriptions_gifting' ) ) ) ); ?> <br />
-	<p class="form-row form-row <?php esc_attr_e( implode( ' ', $email_field_args['class'] ) ); ?>" style="<?php esc_attr_e( implode( '; ', $email_field_args['style_attributes'] ) );?>">
-		<label for="recipient_email[<?php esc_attr_e( $id );?>]">
+	<p class="form-row form-row <?php echo esc_attr( implode( ' ', $email_field_args['class'] ) ); ?>" style="<?php echo esc_attr( implode( '; ', $email_field_args['style_attributes'] ) ); ?>">
+		<label for="recipient_email[<?php echo esc_attr( $id ); ?>]">
 			<?php esc_html_e( "Recipient's Email Address:", 'woocommerce-subscriptions-gifting' ); ?>
 		</label>
-		<input type="email" class="input-text recipient_email" name="recipient_email[<?php esc_attr_e( $id );?>]" id="recipient_email[<?php esc_attr_e( $id );?>]" placeholder="<?php esc_attr_e( $email_field_args['placeholder'] );?>" value="<?php esc_attr_e( $email )?>"/>
+		<input type="email" class="input-text recipient_email" name="recipient_email[<?php echo esc_attr( $id ); ?>]" id="recipient_email[<?php echo esc_attr( $id ); ?>]" placeholder="<?php echo esc_attr( $email_field_args['placeholder'] ); ?>" value="<?php echo esc_attr( $email ); ?>"/>
 		<?php wp_nonce_field( 'wcsg_add_recipient', '_wcsgnonce' ); ?>
 	</p>
 </fieldset>

--- a/templates/related-orders.php
+++ b/templates/related-orders.php
@@ -45,7 +45,7 @@
 				<td class="order-total" data-title="<?php esc_attr_e( 'Total', 'woocommerce-subscriptions-gifting' ); ?>">
 					<?php
 					// translators: price for number of items
-					echo wp_kses_post( sprintf( _n( '%s for %s item', '%s for %s items', $item_count, 'woocommerce-subscriptions-gifting' ), $order->get_formatted_order_total(), $item_count ) );
+					echo wp_kses_post( sprintf( _n( '%1$s for %2$s item', '%1$s for %2$s items', $item_count, 'woocommerce-subscriptions-gifting' ), $order->get_formatted_order_total(), $item_count ) );
 					?>
 				</td>
 				<td class="order-actions">

--- a/woocommerce-subscriptions-gifting.php
+++ b/woocommerce-subscriptions-gifting.php
@@ -391,7 +391,7 @@ class WCS_Gifting {
 				<div id="message" class="error">
 					<p><?php
 						// translators: 1$-2$: opening and closing <strong> tags, 3$ plugin name, 4$:opening link tag, leads to plugin product page, 5$-6$: opening and closing link tags, leads to plugins.php in admin
-						printf( esc_html__( '%1$sWooCommerce Subscriptions Gifting is inactive.%2$s WooCommerce Subscriptions Gifting requires the %4$s%3$s%6$s plugin to be active to work correctly. Please %5$sinstall & activate %3$s &raquo;%6$s',  'woocommerce-subscriptions-gifting' ), '<strong>', '</strong>', esc_html( $plugin_name ) , '<a href="'. esc_url( $plugin_url ) . '">', '<a href="' . esc_url( admin_url( 'plugins.php' ) ) . '">', '</a>' ); ?>
+						printf( esc_html__( '%1$sWooCommerce Subscriptions Gifting is inactive.%2$s WooCommerce Subscriptions Gifting requires the %4$s%3$s%6$s plugin to be active to work correctly. Please %5$sinstall & activate %3$s &raquo;%6$s',  'woocommerce-subscriptions-gifting' ), '<strong>', '</strong>', esc_html( $plugin_name ) , '<a href="' . esc_url( $plugin_url ) . '">', '<a href="' . esc_url( admin_url( 'plugins.php' ) ) . '">', '</a>' ); ?>
 					</p>
 				</div>
 			<?php }


### PR DESCRIPTION
Getting in some coding standard fixes to avoid 🔴 before I implement https://github.com/Prospress/prospress-coding-standards/issues/3

These changes shouldn't affect plugin behavior/functionality - but should still be reviewed carefully.

Some additional background info on the commits:

* 63e34f0 fixes some best practice indentation issues
* 38c7ef7 the `WordPress.WP.I18n` sniff is now part of the WordPress Core rule set. When there is more than 1 placeholder in a translatable string they should be numbered - for RTL languages etc. it means the order can be moved around.
* 1ddc37a fixes some best practice white space issues (`WordPress.Extra` ruleset)
* 54a5596 removes an extra `;`
* 23349a1 fixes a few yoda condition issues. There were a number of fixes in WPCS 0.9.0 for the `WordPress.PHP.YodaConditions` sniff that will now be picked up.
* 3602872 some best practice concatenation tweaks (`WordPress.Extra` ruleset)
* 2f440ff instead of inserting the `$order_by` variable within the `$wpdb->prepare()` string directly it should be run through `prepare()` using a placeholder.
* 36f975a, 639588e and b0f36e1 are probably the most notable of the changes. They change a bunch of the translatable strings to make better use of placeholders rather than a concatenated string + variables approach (which don't translate nicely).
