### PR TITLE
Update and fix Memberships integration

### DIFF
--- a/includes/class-wcsg-memberships-integration.php
+++ b/includes/class-wcsg-memberships-integration.php
@@ -170,26 +170,18 @@ class WCSG_Memberships_Integration {
 				update_post_meta( $args['user_membership_id'], '_subscription_id', $subscription->id );
 
 				// Update the membership end date to align it to the user's subscription
-				if ( $wcm_subscriptions_integration_instance->plan_grants_access_while_subscription_active( $membership_plan->id ) ) {
-
-					$wcm_subscriptions_integration_instance->update_related_membership_dates( $subscription, 'end', $subscription->get_date( 'end' ) );
-				}
+				$wcm_subscriptions_integration_instance->update_related_membership_dates( $subscription, 'end', $subscription->get_date( 'end' ) );
 
 			// If the member user is the purchaser, set the linked subscription to their subscription just in case
 			} else {
 				foreach ( $subscriptions_in_order as $subscription ) {
 					if ( ! isset( $subscription->recipient_user ) ) {
 						update_post_meta( $args['user_membership_id'], '_subscription_id', $subscription->id );
-
-						if ( $wcm_subscriptions_integration_instance->plan_grants_access_while_subscription_active( $membership_plan->id ) ) {
-
-							$wcm_subscriptions_integration_instance->update_related_membership_dates( $subscription, 'end', $subscription->get_date( 'end' ) );
-						}
+						$wcm_subscriptions_integration_instance->update_related_membership_dates( $subscription, 'end', $subscription->get_date( 'end' ) );
 					}
 				}
 			}
 		}
 	}
-
 }
 WCSG_Memberships_Integration::init();

--- a/includes/class-wcsg-memberships-integration.php
+++ b/includes/class-wcsg-memberships-integration.php
@@ -119,7 +119,7 @@ class WCSG_Memberships_Integration {
 
 			foreach ( $user_unique_product_ids as $user_access_granting_product_ids ) {
 
-				$user_granting_product = wc_memberships_cumulative_granting_access_orders_allowed()
+				$user_granting_product = ( 'yes' === get_option( 'wc_memberships_allow_cumulative_access_granting_orders', 'no' ) )
 					? $user_access_granting_product_ids
 					: $user_access_granting_product_ids[0];
 
@@ -151,7 +151,10 @@ class WCSG_Memberships_Integration {
 
 			$order = wc_get_order( $args['order_id'] );
 
-			$wcm_subscriptions_integration_instance = wc_memberships()->get_integrations_instance()->get_subscriptions_instance();
+			// Get the WC Memberships Subscription integration instance
+			$wcm_subscriptions_integration_instance = is_callable( array( wc_memberships(), 'get_integrations_instance' ) )
+				? wc_memberships()->get_integrations_instance()->get_subscriptions_instance()
+				: wc_memberships()->get_subscriptions_integration();
 
 			// check if the member user is a recipient
 			if ( $order->user_id != $args['user_id'] ) {

--- a/includes/class-wcsg-memberships-integration.php
+++ b/includes/class-wcsg-memberships-integration.php
@@ -147,7 +147,7 @@ class WCSG_Memberships_Integration {
 			'product_id' => $args['product_id'],
 		) );
 
-		if ( 1 != count( $subscriptions_in_order ) ) {
+		if ( ! empty( $subscriptions_in_order ) ) {
 
 			$order = wc_get_order( $args['order_id'] );
 
@@ -157,6 +157,10 @@ class WCSG_Memberships_Integration {
 				$recipient_subscription_in_order = array_intersect( array_keys( $subscriptions_in_order ), $recipient_subscriptions );
 
 				$subscription = wcs_get_subscription( reset( $recipient_subscription_in_order ) );
+
+				if ( ! $subscription ) {
+					return;
+				}
 
 				update_post_meta( $args['user_membership_id'], '_subscription_id', $subscription->id );
 				wc_memberships()->get_subscriptions_integration()->update_related_membership_dates( $subscription, 'end', $subscription->get_date( 'end' ) );


### PR DESCRIPTION
Some Background: When WC Memberships links memberships to subscriptions they link it to the subscription in the order with the product. This criteria isn't specific enough in the case of gifted subscription memberships however so Gifting needs to find the subscription in the order with the product for the recipient - this is the job of [`WCSG_Memberships_Integration::update_subscription_id()`](https://github.com/Prospress/woocommerce-subscriptions-gifting/blob/8a8832f7320afbd623dc2ef4bdcac22ab3d7b129/includes/class-wcsg-memberships-integration.php#L143).

However it assumes that if the member user is not equal to the order user that the membership must have been gifted. This might not always be the case and so this PR (200198a):

- makes sure we only attempt to re-link subscriptions with memberships if there is in fact a subscription purchased in the order
- and that the subscription exists.

I also snuck in a few changes (8a8832f) to remove calls to deprecated functions and update `update_subscription_id()` so that it uses the new condition WCM v1.6 introduced before linking subscription end dates [here](https://github.com/skyverge/wc-plugins/blob/df4ec1abd4dfc83a59aacbe413362631245ede4f/woocommerce-memberships/includes/integrations/subscriptions/abstract-wc-memberships-integration-subscriptions.php#L816-L820).

fixes #165