### PR TITLE
Fix Shipping to Recipient Notice Error

### DIFF
--- a/includes/class-wcsg-cart.php
+++ b/includes/class-wcsg-cart.php
@@ -183,5 +183,22 @@ class WCSG_Cart {
 
 		return $cart_item_data;
 	}
+
+	/**
+	 * Checks the cart to see if it contains a gifted subscription renewal.
+	 *
+	 * @return bool
+	 * @since 1.0.1
+	 */
+	public static function contains_gifted_renewal() {
+		$cart_contains_gifted_renewal = false;
+
+		if ( $item = wcs_cart_contains_renewal() ) {
+
+			$cart_contains_gifted_renewal = WCS_Gifting::is_gifted_subscription( $item['subscription_renewal']['subscription_id'] );
+		}
+
+		return $cart_contains_gifted_renewal;
+	}
 }
 WCSG_Cart::init();


### PR DESCRIPTION
In https://github.com/woothemes/woocommerce/commit/da2337b05ba9c3b80e0ca8dd32ed80d9801dd107, WC changed where the `woocommerce_ship_to_different_address_checked` filter is called from. Because Gifting would return `true` and print a notice when it automatically ships to the renewal recipient, that change would cause the HTML output to be broken.

To replicate on `master`:

- Purchase a subscription product and enter a recipient email
- Trigger a pending payment or failed renewal order
- Go to the My Account page and Click "Pay"
- Scroll down to the checkout shipping fields

You should see something similar to:

![screen shot 2016-09-27 at 5 21 49 pm](https://cloud.githubusercontent.com/assets/8490476/18863861/f35eb262-84d6-11e6-8239-a2162646c2b5.png)

This patch moves the printing of the "Shipping to Subscription Recipient" notice to a separate hook and introduces a cart contains gifted renewal helper function. With this change the only noticeable difference is that the notice is inside the shipping field wrapper rather than above it https://cloudup.com/cLcjUXrZA6v vs https://cloudup.com/c19OWkUeZpq.