### PR TITLE
Allow memberships to be granted on parent variable product ids

### DIFF
--- a/includes/class-wcsg-memberships-integration.php
+++ b/includes/class-wcsg-memberships-integration.php
@@ -46,7 +46,7 @@ class WCSG_Memberships_Integration {
 			$grant_access_to_recipients = array();
 
 			foreach ( $order_items as $order_item_id => $order_item ) {
-				if ( wcs_get_canonical_product_id( $order_item ) == $product_id ) {
+				if ( $product_id && in_array( $product_id, array( $order_item['product_id'], $order_item['variation_id'] ) ) ) {
 					if ( isset( $order_item['item_meta']['wcsg_recipient'] ) ) {
 						$grant_access_to_recipients[] = WCS_Gifting::get_order_item_recipient_user_id( $order_item );
 					} else {
@@ -108,10 +108,14 @@ class WCSG_Memberships_Integration {
 
 			foreach ( $order->get_items() as $order_item_id => $order_item ) {
 
-				if ( in_array( wcs_get_canonical_product_id( $order_item ), $all_access_granting_product_ids ) ) {
+				$user_id = ( isset( $order_item['item_meta']['wcsg_recipient'] ) ) ? WCS_Gifting::get_order_item_recipient_user_id( $order_item ) : $order->customer_user;
 
-					$user_id = ( isset( $order_item['item_meta']['wcsg_recipient'] ) ) ? WCS_Gifting::get_order_item_recipient_user_id( $order_item ) : $order->customer_user;
-					$user_unique_product_ids[ $user_id ][] = wcs_get_canonical_product_id( $order_item );
+				if ( in_array( $order_item['product_id'], $all_access_granting_product_ids ) ) {
+					$user_unique_product_ids[ $user_id ][] = $order_item['product_id'];
+				}
+
+				if ( in_array( $order_item['variation_id'], $all_access_granting_product_ids ) ) {
+					$user_unique_product_ids[ $user_id ][] = $order_item['variation_id'];
 				}
 			}
 


### PR DESCRIPTION
WC Memberships allow store owners to grant memberships to variation parent ids so that purchasing any variation child of that product will grant membership. However, because WCSG Memberships integration made use of `wcs_get_canonical_product_id()`, only variation ids or standalone product ids could grant access. This PR fixes that.

To replicate on `master`: 

1. Setup a variable subscription product
2. Go to **WooCommerce->Memberships->Membership Plans->Add Membership Plan**
3. In the _"Grant access to people who purchase"_ field enter the variable product parent not the variation level products (https://cloudup.com/cwb4n30Lg1M).
4. Go the product's page, select a variation, enter a recipient email and add to cart.
5. Checkout
6. Go to **WooCommerce->Memberships** and notice no membership has been granted to the recipient. 

Because `WCSG_Memberships_Integration` contained conditions like: 
```
wcs_get_canonical_product_id( $order_item ) == $product_id
```

the variation id would be compared to the product id in these cases which would cause the check to fail. This PR removes calls to `wcs_get_canonical_product_id` when handling membership granting product ids. 

Fixes #169