### PR TITLE
Add recipient edit field to the edit subscription screen

### DIFF
--- a/includes/class-wcsg-admin.php
+++ b/includes/class-wcsg-admin.php
@@ -15,6 +15,11 @@ class WCSG_Admin {
 		add_filter( 'woocommerce_subscription_settings', __CLASS__ . '::add_settings', 10, 1 );
 
 		add_filter( 'request',  __CLASS__ . '::request_query', 11 , 1 );
+
+		add_action( 'woocommerce_admin_order_data_after_order_details', __CLASS__ . '::display_edit_subscription_recipient_field', 10, 1 );
+
+		// Save recipient user after WC have saved all subscription order items (40)
+		add_action( 'woocommerce_process_shop_order_meta', __CLASS__ . '::save_subscription_recipient_meta', 50, 2 );
 	}
 
 	/**
@@ -130,6 +135,76 @@ class WCSG_Admin {
 		}
 
 		return $vars;
+	}
+
+	/**
+	 * Output a recipient user select field in the edit subscription data metabox.
+	 *
+	 * @param WP_Post $subscription
+	 * @since 1.0.1
+	 */
+	public static function display_edit_subscription_recipient_field( $subscription ) {
+
+		if ( ! wcs_is_subscription( $subscription ) ) {
+			return;
+		} ?>
+
+		<p class="form-field form-field-wide wc-customer-user">
+			<label for="recipient_user"><?php esc_html_e( 'Recipient:', 'woocommerce-subscriptions-gifting' ) ?></label><?php
+			$user_string = '';
+			$user_id     = '';
+			if ( WCS_Gifting::is_gifted_subscription( $subscription ) ) {
+				$user_id     = absint( $subscription->recipient_user );
+				$user        = get_user_by( 'id', $user_id );
+				$user_string = esc_html( $user->display_name ) . ' (#' . absint( $user->ID ) . ' &ndash; ' . esc_html( $user->user_email );
+			} ?>
+			<input type="hidden" class="wc-customer-search" id="recipient_user" name="recipient_user" data-placeholder="<?php esc_attr_e( 'Search for a recipient&hellip;', 'woocommerce-subscriptions-gifting' ); ?>" data-selected="<?php echo esc_attr( $user_string ); ?>" value="<?php echo esc_attr( $user_id ); ?>" data-allow_clear="true"/>
+		</p><?php
+	}
+
+	/**
+	 * Save subscription recipient user meta by updating or deleting _recipient_user post meta.
+	 * Also updates the recipient id stored in subscription line item meta.
+	 *
+	 * @param int $post_id
+	 * @param WP_Post $post
+	 * @since 1.0.1
+	 */
+	public static function save_subscription_recipient_meta( $post_id, $post ) {
+
+		if ( 'shop_subscription' != $post->post_type || ! isset( $_POST['recipient_user'] ) || empty( $_POST['woocommerce_meta_nonce'] ) || ! wp_verify_nonce( $_POST['woocommerce_meta_nonce'], 'woocommerce_save_data' ) ) {
+			return;
+		}
+
+		$recipient_user         = empty( $_POST['recipient_user'] ) ? '' : absint( $_POST['recipient_user'] );
+		$customer_user          = get_post_meta( $post_id, '_customer_user', true );
+		$subscription           = wcs_get_subscription( $post_id );
+		$is_gifted_subscription = WCS_Gifting::is_gifted_subscription( $subscription );
+
+		if ( $recipient_user == $customer_user ) {
+			// Remove the recipient
+			$recipient_user = '';
+			wcs_add_admin_notice( __( 'Error saving subscription recipient: customer and recipient cannot be the same. The recipient user has been removed.', 'woocommerce-subscriptions-gifting' ), 'error' );
+		}
+
+		if ( ( $is_gifted_subscription && $subscription->recipient_user == $recipient_user ) || ( ! $is_gifted_subscription && empty( $recipient_user ) ) ) {
+			// Recipient user remains unchanged - do nothing
+			return;
+		} elseif ( empty( $recipient_user ) ) {
+			delete_post_meta( $post_id, '_recipient_user' );
+
+			// Delete recipient meta from subscription order items
+			foreach ( $subscription->get_items() as $order_item_id => $order_item ) {
+				wc_delete_order_item_meta( $order_item_id, 'wcsg_recipient' );
+			}
+		} else {
+			update_post_meta( $post_id, '_recipient_user', $recipient_user );
+
+			// Update all subscription order items
+			foreach ( $subscription->get_items() as $order_item_id => $order_item ) {
+				wc_update_order_item_meta( $order_item_id, 'wcsg_recipient', 'wcsg_recipient_id_' . $recipient_user );
+			}
+		}
 	}
 }
 WCSG_Admin::init();

--- a/includes/class-wcsg-admin.php
+++ b/includes/class-wcsg-admin.php
@@ -157,8 +157,21 @@ class WCSG_Admin {
 				$user_id     = WCS_Gifting::get_recipient_user( $subscription );
 				$user        = get_user_by( 'id', $user_id );
 				$user_string = esc_html( $user->display_name ) . ' (#' . absint( $user->ID ) . ' &ndash; ' . esc_html( $user->user_email );
-			} ?>
-			<input type="hidden" class="wc-customer-search" id="recipient_user" name="recipient_user" data-placeholder="<?php esc_attr_e( 'Search for a recipient&hellip;', 'woocommerce-subscriptions-gifting' ); ?>" data-selected="<?php echo esc_attr( $user_string ); ?>" value="<?php echo esc_attr( $user_id ); ?>" data-allow_clear="true"/>
+			}
+
+			if ( is_callable( array( 'WCS_Select2', 'render' ) ) ) {
+				WCS_Select2::render( array(
+					'class'       => 'wc-customer-search',
+					'name'        => 'recipient_user',
+					'id'          => 'recipient_user',
+					'placeholder' => esc_attr__( 'Search for a recipient&hellip;', 'woocommerce-subscriptions-gifting' ),
+					'selected'    => $user_string,
+					'value'       => $user_id,
+					'allow_clear' => 'true',
+				) );
+			} else { ?>
+				<input type="hidden" class="wc-customer-search" id="recipient_user" name="recipient_user" data-placeholder="<?php esc_attr_e( 'Search for a recipient&hellip;', 'woocommerce-subscriptions-gifting' ); ?>" data-selected="<?php echo esc_attr( $user_string ); ?>" value="<?php echo esc_attr( $user_id ); ?>" data-allow_clear="true"/><?php
+			}?>
 		</p><?php
 	}
 

--- a/includes/class-wcsg-cart.php
+++ b/includes/class-wcsg-cart.php
@@ -215,7 +215,7 @@ class WCSG_Cart {
 		$recipient_user_id = '';
 
 		if ( isset( $cart_item['subscription_renewal'] ) && WCS_Gifting::is_gifted_subscription( $cart_item['subscription_renewal']['subscription_id'] ) ) {
-			$recipient_id    = get_post_meta( $cart_item['subscription_renewal']['subscription_id'], '_recipient_user', true );
+			$recipient_id    = WCS_Gifting::get_recipient_user( wcs_get_subscription( $cart_item['subscription_renewal']['subscription_id'] ) );
 			$recipient       = get_user_by( 'id', $recipient_id );
 			$recipient_email = $recipient->user_email;
 		} else if ( isset( $cart_item['wcsg_gift_recipients_email'] ) ) {

--- a/includes/class-wcsg-checkout.php
+++ b/includes/class-wcsg-checkout.php
@@ -51,7 +51,7 @@ class WCSG_Checkout {
 			$recipient_user_id = email_exists( $cart_item['wcsg_gift_recipients_email'] );
 
 			if ( is_numeric( $recipient_user_id ) ) {
-				update_post_meta( wcsg_get_objects_id( $subscription ), '_recipient_user', $recipient_user_id );
+				WCS_Gifting::set_recipient_user( $subscription, $recipient_user_id );
 
 				$subscription->set_address( array(
 					'first_name' => get_user_meta( $recipient_user_id, 'shipping_first_name', true ),

--- a/includes/class-wcsg-recipient-management.php
+++ b/includes/class-wcsg-recipient-management.php
@@ -402,7 +402,7 @@ class WCSG_Recipient_Management {
 
 		if ( ! empty( $gifted_subscriptions ) ) {
 			foreach ( $gifted_subscriptions as $subscription_id ) {
-				update_post_meta( $subscription_id, '_recipient_user', 'deleted_recipient' );
+				WCS_Gifting::set_recipient_user( $subscription, 'deleted_recipient' );
 			}
 
 			$recipient      = get_user_by( 'id', $user_id );

--- a/includes/emails/class-wcsg-email-completed-renewal-order.php
+++ b/includes/emails/class-wcsg-email-completed-renewal-order.php
@@ -39,7 +39,7 @@ class WCSG_Email_Completed_Renewal_Order extends WCS_Email_Completed_Renewal_Ord
 			$this->object    = wc_get_order( $order_id );
 			$subscriptions   = wcs_get_subscriptions_for_renewal_order( $order_id );
 			$subscriptions   = array_values( $subscriptions );
-			$recipient_id    = get_post_meta( wcsg_get_objects_id( $subscriptions[0] ), '_recipient_user', true );
+			$recipient_id    = WCS_Gifting::get_recipient_user( wcs_get_subscription( $subscriptions[0] ) );
 			$this->recipient = get_userdata( $recipient_id )->user_email;
 		}
 

--- a/includes/emails/class-wcsg-email-processing-renewal-order.php
+++ b/includes/emails/class-wcsg-email-processing-renewal-order.php
@@ -36,7 +36,7 @@ class WCSG_Email_Processing_Renewal_Order extends WCS_Email_Processing_Renewal_O
 			$this->object    = wc_get_order( $order_id );
 			$subscriptions   = wcs_get_subscriptions_for_renewal_order( $order_id );
 			$subscriptions   = array_values( $subscriptions );
-			$recipient_id    = get_post_meta( wcsg_get_objects_id( $subscriptions[0] ), '_recipient_user', true );
+			$recipient_id    = WCS_Gifting::get_recipient_user( wcs_get_subscription( $subscriptions[0] ) );
 			$this->recipient = get_user_by( 'id', $recipient_id )->user_email;
 		}
 

--- a/woocommerce-subscriptions-gifting.php
+++ b/woocommerce-subscriptions-gifting.php
@@ -562,7 +562,7 @@ class WCS_Gifting {
 	 */
 	public static function set_recipient_user( &$subscription, $user_id, $save = 'save', $meta_id = '' ) {
 
-		if ( function_exists( 'wcs_set_objects_property' ) ) { // Subscriptions 2.2.0+
+		if ( function_exists( 'wcs_set_objects_property' ) && false === wcsg_is_woocommerce_pre( '3.0' ) ) { // Subscriptions 2.2.0+
 
 			wcs_set_objects_property( $subscription, 'recipient_user', $user_id, $save, $meta_id );
 
@@ -590,7 +590,7 @@ class WCS_Gifting {
 	 */
 	public static function delete_recipient_user( &$subscription, $save = 'save', $meta_id = '' ) {
 
-		if ( function_exists( 'wcs_delete_objects_property' ) ) { // Subscriptions 2.2.0+
+		if ( function_exists( 'wcs_delete_objects_property' ) && false === wcsg_is_woocommerce_pre( '3.0' ) ) { // Subscriptions 2.2.0+ and WC 3.0+
 
 			wcs_delete_objects_property( $subscription, 'recipient_user', $save, $meta_id );
 

--- a/woocommerce-subscriptions-gifting.php
+++ b/woocommerce-subscriptions-gifting.php
@@ -550,5 +550,63 @@ class WCS_Gifting {
 
 		return $recipient_user_id;
 	}
+
+	/**
+	 * Set the recipient user ID on a subscription
+	 *
+	 * @param WC_Subscription $subscription
+	 * @param int $user_id The user ID of the user to set as the recipient on the subscription
+	 * @param string $save Whether to save the data or not, 'save' to save the data, otherwise it won't be saved.
+	 * @param int $meta_id The meta ID of existing meta data if you wish to overwrite an existing recipient meta value.
+	 * @return null
+	 */
+	public static function set_recipient_user( &$subscription, $user_id, $save = 'save', $meta_id = '' ) {
+
+		if ( function_exists( 'wcs_set_objects_property' ) ) { // Subscriptions 2.2.0+
+
+			wcs_set_objects_property( $subscription, 'recipient_user', $user_id, $save, $meta_id );
+
+		} else {
+
+			$subscription->recipient_user = $recipient_user_id;
+
+			if ( 'save' === $save ) {
+				if ( ! empty( $meta_id ) ) {
+					update_metadata_by_mid( 'post', $meta_id, $user_id, '_recipient_user' );
+				} else {
+					update_post_meta( $subscription->id, '_recipient_user', $user_id );
+				}
+			}
+		}
+	}
+
+	/**
+	 * Delete the recipient user ID on a subscription
+	 *
+	 * @param WC_Subscription $subscription
+	 * @param string $save Whether to save the data or not, 'save' to save the data, otherwise it won't be saved.
+	 * @param int $meta_id The meta ID of existing recipient meta data if you wish to only delete a field specified by ID
+	 * @return null
+	 */
+	public static function delete_recipient_user( &$subscription, $save = 'save', $meta_id = '' ) {
+
+		if ( function_exists( 'wcs_delete_objects_property' ) ) { // Subscriptions 2.2.0+
+
+			wcs_delete_objects_property( $subscription, 'recipient_user', $save, $meta_id );
+
+		} else {
+
+			unset( $subscription->recipient_user );
+
+			// Save the data
+			if ( 'save' === $save ) {
+				if ( ! empty( $meta_id ) ) {
+					delete_metadata_by_mid( 'post', $meta_id );
+				} else {
+					delete_post_meta( $subscription->id, '_recipient_user' );
+				}
+			}
+		}
+	}
 }
 WCS_Gifting::init();


### PR DESCRIPTION
This adds a recipient selection field to the edit subscription screen. 

![screen shot 2016-10-11 at 1 48 48 pm](https://cloud.githubusercontent.com/assets/8490476/19258230/8cafb424-8fb9-11e6-8e86-05cf2be0fad7.png)

This field allows admin to add, edit or remove the recipient from the subscription. The only restriction on this field is that the recipient and customer cannot be the same user.

Because subscription line items also store the recipient id, using this field will also update or delete subscription order item meta. 
