### PR TITLE
Only display shipping address fields on the new recipient form when shipping is enabled

### DIFF
--- a/includes/class-wcsg-recipient-details.php
+++ b/includes/class-wcsg-recipient-details.php
@@ -124,16 +124,43 @@ class WCSG_Recipient_Details {
 	 */
 	public static function get_new_recipient_account_form_fields( $country ) {
 
-		$form_fields = WC()->countries->get_address_fields( $country, 'shipping_', true );
+		$shipping_fields = array();
 
-		$name_fields = array( 'shipping_first_name', 'shipping_last_name' );
+		if ( wc_shipping_enabled() ) {
+			$shipping_fields = WC()->countries->get_address_fields( $country, 'shipping_', true );
+
+			// We have our own name fields, so hide and make the shipping name fields not required
+			foreach ( array( 'shipping_first_name', 'shipping_last_name' ) as $field_key ) {
+				$shipping_fields[ $field_key ]['type'] = 'hidden';
+				$shipping_fields[ $field_key ]['required'] = false;
+			}
+
+			// Add the option for users to also set their billing address
+			$shipping_fields['set_billing'] = array(
+				'type'     => 'checkbox',
+				'label'    => esc_html__( 'Set my billing address to the same as above.', 'woocommerce-subscriptions-gifting' ),
+				'class'    => array( 'form-row' ),
+				'required' => false,
+				'default'  => 1,
+			);
+		}
+
 		$personal_fields = array();
 
-		//move the name fields to the front of the array for display purposes.
-		foreach ( $name_fields as $element ) {
-			$personal_fields[ $element ] = $form_fields[ $element ];
-			unset( $form_fields[ $element ] );
-		}
+		$personal_fields['first_name'] = array(
+			'label'        => esc_html__( 'First Name', 'woocommerce-subscriptions-gifting' ),
+			'required'     => true,
+			'class'        => array( 'form-row-first' ),
+			'autocomplete' => 'given-name',
+		);
+
+		$personal_fields['last_name'] = array(
+			'label'        => esc_html__( 'Last Name', 'woocommerce-subscriptions-gifting' ),
+			'required'     => true,
+			'class'        => array( 'form-row-last' ),
+			'clear'        => true,
+			'autocomplete' => 'family-name',
+		);
 
 		$personal_fields['new_password'] = array(
 			'type'     => 'password',
@@ -149,15 +176,8 @@ class WCSG_Recipient_Details {
 			'password' => true,
 			'class'    => array( 'form-row-last' ),
 		);
-		$form_fields['set_billing'] = array(
-			'type'     => 'checkbox',
-			'label'    => esc_html__( 'Set my billing address to the same as above.', 'woocommerce-subscriptions-gifting' ),
-			'class'    => array( 'form-row' ),
-			'required' => false,
-			'default'  => 1,
-		);
 
-		return array_merge( $personal_fields, $form_fields );
+		return apply_filters( 'wcsg_new_recipient_account_details_fields', array_merge( $personal_fields, $shipping_fields ) );
 	}
 }
 WCSG_Recipient_Details::init();

--- a/templates/new-recipient-account.php
+++ b/templates/new-recipient-account.php
@@ -13,7 +13,7 @@
 $form_fields = WCSG_Recipient_Details::get_new_recipient_account_form_fields( WC()->countries->get_base_country() );
 
 foreach ( $form_fields as $key => $field ) {
-	if ( 'shipping_country' == $key ) { ?>
+	if ( 'shipping_company' == $key ) { ?>
 		<h3> <?php esc_html_e( 'Shipping Address', 'woocommerce-subscriptions-gifting' ); ?></h3><?php
 	}
 	$value = isset( $field['default'] ) ? $field['default'] : '';


### PR DESCRIPTION
When an account is created for a recipient, on their first login they are displayed with a form to collect some extra information (like their shipping address) and change their password.

If you disable shipping from WC Settings (https://cloudup.com/cohPOMXyU7W) however, the shipping address fields are still displayed. On top of there being no reason to collect the recipient's shipping address in this scenario, this actually makes the form unsubmittable because the country is a required field but WC cannot populate the dropdown (https://cloudup.com/cVhtks_f9sU).

This PR fixes that and introduces a filter to allow third parties to filter the fields displayed. 

- 63ed508 - Moves the **Shipping Address** heading so that it appears above the Company field _before: https://cloudup.com/cQlbyUDslqx -> after: https://cloudup.com/cJx9aH5noft_
- ed5ee35 - Introduces a filter and only adds the shipping address fields when shipping is enabled _before: https://cloudup.com/cRPko4y5qbv -> after: https://cloudup.com/cvW6jLf70Kf_ 
- 7e3fcf7 - Updates the validation and save function so that it doesn't expect all default fields to be present.

To test:
- Disable shipping from the WC Settings (**WooCommerce -> Settings -> General Tab -> Shipping Location(s) -> Disable shipping & shipping calculations**)
- Purchase a subscription and enter a recipient email address who isn't registered (you can use something like http://www.fakemailgenerator.com/ to generate an email address and receive emails)
- Wait to receive the login details for the recipient account. 
- Login to the My Account page using the recipient credentials. Once you are logged in you should be redirected to the Account Details Form
- To continue testing after submitting the form without needing to recreate new recipient accounts, you will need to add the user meta flag `wcsg_update_account` with the value `true` to the recipient user.