### PR TITLE
Add wc_print_notices()

### DIFF
--- a/templates/new-recipient-account.php
+++ b/templates/new-recipient-account.php
@@ -1,3 +1,5 @@
+<?php print wc_print_notices(); ?>
+
 <p><?php
 	esc_html_e( 'We just need a few details from you to complete your account creation.', 'woocommerce-subscriptions-gifting' ); ?><br /><?php
 	// translators: 1$: user's email, 2$-3$: opening and closing link tags, logs the user out.


### PR DESCRIPTION
Add wc_print_notices() to the top of template so user can see validation errors. Currently without this, validation notices set are never shown.