### PR TITLE
Allow recipients to pay renewal orders post WCS v2.1

### DIFF
--- a/includes/class-wcsg-recipient-management.php
+++ b/includes/class-wcsg-recipient-management.php
@@ -18,7 +18,7 @@ class WCSG_Recipient_Management {
 
 		add_filter( 'woocommerce_subscription_related_orders', __CLASS__ . '::maybe_remove_parent_order', 11, 4 );
 
-		add_filter( 'user_has_cap', __CLASS__ . '::grant_recipient_capabilities', 11, 3 );
+		add_filter( 'user_has_cap', __CLASS__ . '::grant_recipient_capabilities', 20, 3 );
 
 		add_action( 'delete_user_form', __CLASS__ . '::maybe_display_delete_recipient_warning', 10 );
 
@@ -65,7 +65,22 @@ class WCSG_Recipient_Management {
 							}
 						}
 					}
-					break;
+				break;
+				case 'pay_for_order' :
+					$user_id = $args[1];
+					$order   = wc_get_order( $args[2] );
+
+					if ( $order && wcs_order_contains_subscription( $order, 'any' ) ) {
+						$subscriptions = wcs_get_subscriptions_for_renewal_order( $order );
+
+						foreach ( $subscriptions as $subscription ) {
+							if ( $user_id == $subscription->recipient_user ) {
+								$allcaps['pay_for_order'] = true;
+								break;
+							}
+						}
+					}
+				break;
 			}
 		}
 		return $allcaps;


### PR DESCRIPTION
WC Subscriptions v2.1 added a new user has capability check when paying for renewal orders (https://github.com/Prospress/woocommerce-subscriptions/pull/1716). In order to maintain the feature which allows recipients to pay for renewal orders, Gifting must grant recipients that capability.

I also had to move `grant_recipient_capabilities()` back on its priority to ensure Subscriptions doesn't remove the capability ([here](https://github.com/Prospress/woocommerce-subscriptions/pull/1716/files#diff-7c66e9af84fe53fb819cc1a478205e1dR357)) after we've granted it.

To replicate:
- Purchase a subscription product for a test recipient
- Go to the edit subscription admin screen and trigger the "Create pending renewal order" action 
- Login as the recipient and view the newly created subscription with the pending order
- In the related order table Click pay
  - on `master` you would receive the "That doesn't appear to be your order." error notice. (https://cldup.com/ILT5dums1q.png)
  - on this branch, the cart is loaded correctly and the recipient can pay for the order

fixes #176