### PR TITLE
change the is subscriptions active dependency check

### DIFF
--- a/woocommerce-subscriptions-gifting.php
+++ b/woocommerce-subscriptions-gifting.php
@@ -45,7 +45,7 @@ if ( ! is_woocommerce_active() || version_compare( get_option( 'woocommerce_db_v
 	return;
 }
 
-if ( ! is_plugin_active( 'woocommerce-subscriptions/woocommerce-subscriptions.php' ) || version_compare( get_option( 'woocommerce_subscriptions_active_version' ), WCS_Gifting::$wcs_minimum_supported_version, '<' ) ) {
+if ( ! class_exists( 'WC_Subscriptions' ) || version_compare( get_option( 'woocommerce_subscriptions_active_version' ), WCS_Gifting::$wcs_minimum_supported_version, '<' ) ) {
 	add_action( 'admin_notices', 'WCS_Gifting::plugin_dependency_notices' );
 	return;
 }


### PR DESCRIPTION
Ticket: https://woothemes.zendesk.com/agent/tickets/508954

This small patch changes the WooCommerce Subscriptions dependency condition from a `is_plugin_active()` to a `class_exists()` check. `is_plugin_active()` requires the subscription directory to remain unchanged, however pre-released versions will typically have a different folder name. This means pre-released versions of Subscriptions aren't recognised by Gifting, causing it to deactivate itself. 

This patch simply changes `is_plugin_active( 'woocommerce-subscriptions/woocommerce-subscriptions.php' )` to `class_exists( 'WC_Subscriptions' )`.