### PR TITLE
Add pot file

### DIFF
--- a/languages/woocommerce-subscriptions-gifting.pot
+++ b/languages/woocommerce-subscriptions-gifting.pot
@@ -1,0 +1,465 @@
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-02-08 18:28+0100\n"
+"PO-Revision-Date: 2017-02-08 18:20+0100\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"X-Generator: Poedit 1.8.7.1\n"
+"X-Poedit-Basepath: .\n"
+"X-Poedit-KeywordsList: __;__e;_n:1,2;_x:1,2c;_ex:1,2c;_nx:4c,1,2;esc_html__;"
+"esc_attr__;esc_html_e;esc_attr_e\n"
+"X-Poedit-SearchPath-0: .\n"
+
+#: includes/class-wcsg-admin.php:54
+#, php-format
+msgctxt ""
+"Subscription title on admin table. (e.g.: #211 for John Doe Purchased by: "
+"Jane Doe)"
+msgid "%1$s for %2$s purchased by %3$s"
+msgstr ""
+
+#: includes/class-wcsg-admin.php:94
+msgid "Gifting Subscriptions"
+msgstr ""
+
+#: includes/class-wcsg-admin.php:99
+msgid "Gifting Checkbox Text"
+msgstr ""
+
+#: includes/class-wcsg-admin.php:100
+msgid ""
+"Customise the text displayed on the front-end next to the checkbox to select "
+"the product/cart item as a gift."
+msgstr ""
+
+#: includes/class-wcsg-admin.php:102 templates/html-add-recipient.php:4
+msgid "This is a gift"
+msgstr ""
+
+#: includes/class-wcsg-cart.php:79 includes/class-wcsg-checkout.php:115
+#: includes/class-wcsg-product.php:38
+msgid "There was an error with your request. Please try again.."
+msgstr ""
+
+#: includes/class-wcsg-cart.php:93
+msgid "Recipient: "
+msgstr ""
+
+#: includes/class-wcsg-cart.php:108
+msgid ""
+"You cannot add additional products to the cart. Please pay for the "
+"subscription renewal first."
+msgstr ""
+
+#: includes/class-wcsg-checkout.php:178
+msgid "Shipping to the subscription recipient."
+msgstr ""
+
+#: includes/class-wcsg-download-handler.php:104
+msgid "Downloadable Products"
+msgstr ""
+
+#: includes/class-wcsg-download-handler.php:105
+msgid "Allow both purchaser and recipient to download subscription products."
+msgstr ""
+
+#: includes/class-wcsg-download-handler.php:109
+msgid ""
+"If you want both the recipient and purchaser of a subscription to have "
+"access to downloadable products."
+msgstr ""
+
+#: includes/class-wcsg-download-handler.php:155
+msgid "Recipient"
+msgstr ""
+
+#: includes/class-wcsg-download-handler.php:155
+msgid "Purchaser"
+msgstr ""
+
+#: includes/class-wcsg-download-handler.php:295
+#, php-format
+msgid "File %d"
+msgstr ""
+
+#: includes/class-wcsg-query.php:48
+msgid "Account Details"
+msgstr ""
+
+#: includes/class-wcsg-recipient-addresses.php:63
+#, php-format
+msgid ""
+"%1$sNote:%2$s This will not update the shipping address of subscriptions you "
+"have purchased for others."
+msgstr ""
+
+#: includes/class-wcsg-recipient-addresses.php:66
+#, php-format
+msgid ""
+"%1$sNote:%2$s This will not update the billing address of subscriptions "
+"purchased for you by someone else."
+msgstr ""
+
+#: includes/class-wcsg-recipient-details.php:62
+msgid "Please enter your name."
+msgstr ""
+
+#: includes/class-wcsg-recipient-details.php:66
+msgid "Please enter both password fields."
+msgstr ""
+
+#: includes/class-wcsg-recipient-details.php:68
+msgid "Passwords do not match."
+msgstr ""
+
+#: includes/class-wcsg-recipient-details.php:73
+msgid "is a required field."
+msgstr ""
+
+#: includes/class-wcsg-recipient-details.php:78
+msgid "Please enter a valid postcode/ZIP."
+msgstr ""
+
+#: includes/class-wcsg-recipient-details.php:112
+msgid "Your account has been updated."
+msgstr ""
+
+#: includes/class-wcsg-recipient-details.php:117
+msgid ""
+"There was an error with your request to update your account. Please try "
+"again.."
+msgstr ""
+
+#: includes/class-wcsg-recipient-details.php:140
+msgid "New Password"
+msgstr ""
+
+#: includes/class-wcsg-recipient-details.php:147
+msgid "Confirm New Password"
+msgstr ""
+
+#: includes/class-wcsg-recipient-details.php:154
+msgid "Set my billing address to the same as above."
+msgstr ""
+
+#: includes/class-wcsg-recipient-management.php:109
+msgid "Suspend"
+msgstr ""
+
+#: includes/class-wcsg-recipient-management.php:114
+msgid "Reactivate"
+msgstr ""
+
+#: includes/class-wcsg-recipient-management.php:121
+msgid "Cancel"
+msgstr ""
+
+#: includes/class-wcsg-recipient-management.php:463
+msgid "WARNING:"
+msgstr ""
+
+#: includes/class-wcsg-recipient-management.php:464
+msgid "The following recipient will be removed from their subscriptions:"
+msgid_plural ""
+"The following recipients will be removed from their subscriptions:"
+msgstr[0] ""
+msgstr[1] ""
+
+#: includes/class-wcsg-recipient-management.php:477
+msgid "Subscription"
+msgstr ""
+
+#: includes/emails/class-wcsg-email-completed-renewal-order.php:13
+msgid "Completed Renewal Order - Recipient"
+msgstr ""
+
+#: includes/emails/class-wcsg-email-completed-renewal-order.php:14
+msgid ""
+"Renewal order complete emails are sent to the recipient when a subscription "
+"renewal order is marked complete and usually indicates that the item for "
+"that renewal period has been shipped."
+msgstr ""
+
+#: includes/emails/class-wcsg-email-completed-renewal-order.php:17
+msgid "Your renewal order is complete"
+msgstr ""
+
+#: includes/emails/class-wcsg-email-completed-renewal-order.php:18
+msgid "Your {blogname} renewal order from {order_date} is complete"
+msgstr ""
+
+#: includes/emails/class-wcsg-email-completed-renewal-order.php:21
+msgid "Your subscription renewal order is complete - download your files"
+msgstr ""
+
+#: includes/emails/class-wcsg-email-completed-renewal-order.php:22
+msgid ""
+"Your {blogname} subscription renewal order from {order_date} is complete - "
+"download your files"
+msgstr ""
+
+#: includes/emails/class-wcsg-email-customer-new-account.php:17
+msgid "New Recipient Account"
+msgstr ""
+
+#: includes/emails/class-wcsg-email-customer-new-account.php:18
+msgid ""
+"New account notification emails are sent to the subscription recipient when "
+"an account is created for them."
+msgstr ""
+
+#: includes/emails/class-wcsg-email-customer-new-account.php:21
+msgid "Your account on {site_title}"
+msgstr ""
+
+#: includes/emails/class-wcsg-email-customer-new-account.php:22
+msgid "Welcome to {site_title}"
+msgstr ""
+
+#: includes/emails/class-wcsg-email-processing-renewal-order.php:13
+msgid "Processing Renewal Order - Recipient"
+msgstr ""
+
+#: includes/emails/class-wcsg-email-processing-renewal-order.php:14
+msgid ""
+"This is an order notification sent to the recipient after payment for a "
+"subscription renewal order is completed. It contains the renewal order "
+"details."
+msgstr ""
+
+#: includes/emails/class-wcsg-email-processing-renewal-order.php:17
+msgid "Thank you for your order"
+msgstr ""
+
+#: includes/emails/class-wcsg-email-processing-renewal-order.php:18
+msgid "Your {blogname} renewal order receipt from {order_date}"
+msgstr ""
+
+#: includes/emails/class-wcsg-email-recipient-new-initial-order.php:15
+msgid "New Initial Order - Recipient"
+msgstr ""
+
+#: includes/emails/class-wcsg-email-recipient-new-initial-order.php:16
+msgid ""
+"This email is sent to recipients notifying them of subscriptions purchased "
+"for them."
+msgstr ""
+
+#: includes/emails/class-wcsg-email-recipient-new-initial-order.php:19
+msgid "New Order"
+msgstr ""
+
+#: includes/emails/class-wcsg-email-recipient-new-initial-order.php:20
+msgid "Your new subscriptions at {site_title}"
+msgstr ""
+
+#: templates/emails/new-recipient-customer.php:16
+#: templates/emails/plain/new-recipient-customer.php:14
+#: templates/emails/plain/recipient-new-initial-order.php:12
+#: templates/emails/recipient-new-initial-order.php:16
+msgid "Hi there,"
+msgstr ""
+
+#: templates/emails/new-recipient-customer.php:17
+#: templates/emails/plain/new-recipient-customer.php:15
+#, php-format
+msgid ""
+"%1$s just purchased a subscription for you at %2$s so we've created an "
+"account for you to manage the subscription."
+msgstr ""
+
+#: templates/emails/new-recipient-customer.php:19
+#: templates/emails/plain/new-recipient-customer.php:17
+#, php-format
+msgid "Your username is: %s"
+msgstr ""
+
+#: templates/emails/new-recipient-customer.php:20
+#: templates/emails/plain/new-recipient-customer.php:18
+#, php-format
+msgid "Your password has been automatically generated: %s"
+msgstr ""
+
+#: templates/emails/new-recipient-customer.php:22
+#: templates/emails/plain/new-recipient-customer.php:20
+#, php-format
+msgid ""
+"To complete your account we just need you to fill in your shipping address "
+"and you to change your password here: %s."
+msgstr ""
+
+#: templates/emails/new-recipient-customer.php:23
+msgid "My Account Details"
+msgstr ""
+
+#: templates/emails/new-recipient-customer.php:25
+#: templates/emails/plain/new-recipient-customer.php:21
+#, php-format
+msgid ""
+"Once completed you may access your account area to view your subscription "
+"here: %s."
+msgstr ""
+
+#: templates/emails/new-recipient-customer.php:26
+msgid "My Account"
+msgstr ""
+
+#: templates/emails/plain/recipient-new-initial-order.php:14
+#: templates/emails/recipient-new-initial-order.php:17
+#, php-format
+msgid "%1$s just purchased %2$s for you at %3$s."
+msgstr ""
+
+#: templates/emails/plain/recipient-new-initial-order.php:14
+#: templates/emails/recipient-new-initial-order.php:17
+msgid "a subscription"
+msgid_plural "subscriptions"
+msgstr[0] ""
+msgstr[1] ""
+
+#: templates/emails/plain/recipient-new-initial-order.php:15
+#: templates/emails/recipient-new-initial-order.php:18
+#, php-format
+msgid " Details of the %s are shown below."
+msgstr ""
+
+#: templates/emails/plain/recipient-new-initial-order.php:15
+#: templates/emails/plain/recipient-new-initial-order.php:22
+#: templates/emails/recipient-new-initial-order.php:18
+#: templates/emails/recipient-new-initial-order.php:31
+msgid "subscription"
+msgid_plural "subscriptions"
+msgstr[0] ""
+msgstr[1] ""
+
+#: templates/emails/plain/recipient-new-initial-order.php:20
+#: templates/emails/recipient-new-initial-order.php:26
+msgid ""
+"We noticed you didn't have an account so we created one for you. Your "
+"account login details will have been sent to you in a separate email."
+msgstr ""
+
+#: templates/emails/plain/recipient-new-initial-order.php:22
+#, php-format
+msgid "You may access your account area to view your new %1$s here: %2$s."
+msgstr ""
+
+#: templates/emails/plain/recipient-new-initial-order.php:27
+#: templates/emails/recipient-new-initial-order.php:46
+#, php-format
+msgid "Subscription #%s"
+msgstr ""
+
+#: templates/emails/recipient-new-initial-order.php:30
+#, php-format
+msgid ""
+"You may access your account area to view your new %1$s here: %2$sMy Account"
+"%3$s."
+msgstr ""
+
+#: templates/emails/recipient-new-initial-order.php:50
+msgid "Product"
+msgstr ""
+
+#: templates/emails/recipient-new-initial-order.php:51
+msgid "Quantity"
+msgstr ""
+
+#: templates/emails/recipient-new-initial-order.php:52
+msgid "Price"
+msgstr ""
+
+#: templates/html-add-recipient.php:8
+msgid "Recipient's Email Address:"
+msgstr ""
+
+#: templates/new-recipient-account.php:4
+msgid "We just need a few details from you to complete your account creation."
+msgstr ""
+
+#: templates/new-recipient-account.php:6
+#, php-format
+msgid "(not %1$s? %2$sSign out%3$s)"
+msgstr ""
+
+#: templates/new-recipient-account.php:19
+msgid "Shipping Address"
+msgstr ""
+
+#: templates/new-recipient-account.php:32
+msgid "Save"
+msgstr ""
+
+#: templates/related-orders.php:2
+msgid "Related Orders"
+msgstr ""
+
+#: templates/related-orders.php:9
+msgid "Order"
+msgstr ""
+
+#: templates/related-orders.php:10 templates/related-orders.php:32
+msgid "Date"
+msgstr ""
+
+#: templates/related-orders.php:11 templates/related-orders.php:35
+msgid "Status"
+msgstr ""
+
+#: templates/related-orders.php:12 templates/related-orders.php:45
+msgid "Total"
+msgstr ""
+
+#: templates/related-orders.php:23
+msgid "Order Number"
+msgstr ""
+
+#: templates/related-orders.php:48
+#, php-format
+msgid "%1$s for %2$s item"
+msgid_plural "%1$s for %2$s items"
+msgstr[0] ""
+msgstr[1] ""
+
+#: woocommerce-subscriptions-gifting.php:178
+msgid "Please enter someone else's email address."
+msgstr ""
+
+#: woocommerce-subscriptions-gifting.php:182
+msgid " Invalid email address."
+msgstr ""
+
+#: woocommerce-subscriptions-gifting.php:373
+#, php-format
+msgid ""
+"%1$sWooCommerce Subscriptions Gifting Membership integration is inactive."
+"%2$s In order to integrate with WooCommerce Memberships, WooCommerce "
+"Subscriptions Gifting requires %3$s %4$s or newer. %5$sPlease update &raquo;"
+"%6$s %7$s%8$sNote: All other WooCommerce Subscriptions Gifting features will "
+"remain available, however purchasing membership plans for recipients will "
+"fail to grant the membership to the gift recipient.%9$s"
+msgstr ""
+
+#: woocommerce-subscriptions-gifting.php:376
+#, php-format
+msgid ""
+"%1$sWooCommerce Subscriptions Gifting is inactive.%2$s This version of "
+"WooCommerce Subscriptions Gifting requires %3$s %4$s or newer. %5$sPlease "
+"update &raquo;%6$s"
+msgstr ""
+
+#: woocommerce-subscriptions-gifting.php:394
+#, php-format
+msgid ""
+"%1$sWooCommerce Subscriptions Gifting is inactive.%2$s WooCommerce "
+"Subscriptions Gifting requires the %4$s%3$s%6$s plugin to be active to work "
+"correctly. Please %5$sinstall & activate %3$s &raquo;%6$s"
+msgstr ""


### PR DESCRIPTION
Users can easily translate a plugin with the plugin Loco Translate. But it's difficult for non-developers to get the internationalized strings for non-developers. I propose to provide the .pot file wit the plugin to ease the translation process. 