### PR TITLE
WC 3.0 compatibility

### DIFF
--- a/includes/class-wcsg-admin.php
+++ b/includes/class-wcsg-admin.php
@@ -28,7 +28,7 @@ class WCSG_Admin {
 
 		if ( 'order_title' == $column && WCS_Gifting::is_gifted_subscription( $subscription ) ) {
 
-			$recipient_id   = $subscription->recipient_user;
+			$recipient_id   = WCS_Gifting::get_recipient_user( $subscription );
 			$recipient_user = get_userdata( $recipient_id );
 			$recipient_name = '<a href="' . esc_url( get_edit_user_link( $recipient_id ) ) . '">';
 

--- a/includes/class-wcsg-admin.php
+++ b/includes/class-wcsg-admin.php
@@ -51,7 +51,7 @@ class WCSG_Admin {
 			$purchaser_name .= '</a>';
 
 			// translators: $1: is subscription order number,$2: is recipient user's name, $3: is the purchaser user's name
-			$column_content = sprintf( _x( '%1$s for %2$s purchased by %3$s', 'Subscription title on admin table. (e.g.: #211 for John Doe Purchased by: Jane Doe)', 'woocommerce-subscriptions-gifting' ), '<a href="' . esc_url( get_edit_post_link( $subscription->id ) ) . '">#<strong>' . esc_attr( $subscription->get_order_number() ) . '</strong></a>', $recipient_name, $purchaser_name );
+			$column_content = sprintf( _x( '%1$s for %2$s purchased by %3$s', 'Subscription title on admin table. (e.g.: #211 for John Doe Purchased by: Jane Doe)', 'woocommerce-subscriptions-gifting' ), '<a href="' . esc_url( get_edit_post_link( wcsg_get_objects_id( $subscription ) ) ) . '">#<strong>' . esc_attr( $subscription->get_order_number() ) . '</strong></a>', $recipient_name, $purchaser_name );
 
 			$column_content .= '</div>';
 		}

--- a/includes/class-wcsg-cart.php
+++ b/includes/class-wcsg-cart.php
@@ -199,5 +199,37 @@ class WCSG_Cart {
 
 		return $cart_contains_gifted_renewal;
 	}
+
+	/**
+	 * Retrieve a recipient user's ID from a cart item. This function will also create a new user
+	 * if the recipient user's email doesn't already exist.
+	 *
+	 * @param array $cart_item
+	 * @return string the recipient id. If the cart item doesn't belong to a recipient an empty string is returned
+	 * @since 1.0.1
+	 */
+	public static function get_recipient_from_cart_item( $cart_item ) {
+		$recipient_email   = '';
+		$recipient_user_id = '';
+
+		if ( isset( $cart_item['subscription_renewal'] ) && WCS_Gifting::is_gifted_subscription( $cart_item['subscription_renewal']['subscription_id'] ) ) {
+			$recipient_id    = get_post_meta( $cart_item['subscription_renewal']['subscription_id'], '_recipient_user', true );
+			$recipient       = get_user_by( 'id', $recipient_id );
+			$recipient_email = $recipient->user_email;
+		} else if ( isset( $cart_item['wcsg_gift_recipients_email'] ) ) {
+			$recipient_email = $cart_item['wcsg_gift_recipients_email'];
+		}
+
+		if ( ! empty( $recipient_email ) ) {
+			$recipient_user_id = email_exists( $recipient_email );
+
+			// Create a new user if the recipient's email doesn't already exist
+			if ( ! $recipient_user_id ) {
+				$recipient_user_id = WCS_Gifting::create_recipient_user( $recipient_email );
+			}
+		}
+
+		return $recipient_user_id;
+	}
 }
 WCSG_Cart::init();

--- a/includes/class-wcsg-checkout.php
+++ b/includes/class-wcsg-checkout.php
@@ -61,7 +61,7 @@ class WCSG_Checkout {
 			$recipient_user_id = email_exists( $cart_item['wcsg_gift_recipients_email'] );
 
 			if ( is_numeric( $recipient_user_id ) ) {
-				update_post_meta( $subscription->id, '_recipient_user', $recipient_user_id );
+				update_post_meta( wcsg_get_objects_id( $subscription ), '_recipient_user', $recipient_user_id );
 
 				$subscription->set_address( array(
 					'first_name' => get_user_meta( $recipient_user_id, 'shipping_first_name', true ),

--- a/includes/class-wcsg-checkout.php
+++ b/includes/class-wcsg-checkout.php
@@ -143,10 +143,10 @@ class WCSG_Checkout {
 		$shipping_fields = WC()->countries->get_address_fields( '', 'shipping_' );
 
 		if ( array_key_exists( $key, $shipping_fields ) && WCSG_Cart::contains_gifted_renewal() ) {
-
-			$item         = wcs_cart_contains_renewal();
-			$subscription = wcs_get_subscription( $item['subscription_renewal']['subscription_id'] );
-			$value        = get_user_meta( $subscription->recipient_user, $key, true );
+			$item              = wcs_cart_contains_renewal();
+			$subscription      = wcs_get_subscription( $item['subscription_renewal']['subscription_id'] );
+			$recipient_user_id = WCS_Gifting::get_recipient_user( $subscription );
+			$value             = get_user_meta( $recipient_user_id, $key, true );
 		}
 
 		return $value;

--- a/includes/class-wcsg-download-handler.php
+++ b/includes/class-wcsg-download-handler.php
@@ -388,7 +388,13 @@ class WCSG_Download_Handler {
 		foreach ( $downloads as $download ) {
 
 			if ( $product->has_file( $download->download_id ) ) {
-				$files[ $download->download_id ]                 = $product->get_file( $download->download_id );
+				if ( wcsg_is_woocommerce_pre( '3.0' ) ) {
+					$files[ $download->download_id ] = $product->get_file( $download->download_id );
+				} else {
+					$file                            = $product->get_file( $download->download_id );
+					$files[ $download->download_id ] = $file->get_data();
+				}
+
 				$files[ $download->download_id ]['download_url'] = add_query_arg(
 					array(
 						'download_file' => $product_id,

--- a/includes/class-wcsg-download-handler.php
+++ b/includes/class-wcsg-download-handler.php
@@ -270,8 +270,9 @@ class WCSG_Download_Handler {
 			$subscription         = wcs_get_subscription( $order_id );
 			$download_permissions = self::get_subscription_download_permissions( $order_id, 'permission_id' );
 			$file_names           = array();
+			$billing_email        = is_callable( array( $subscription, 'get_billing_email' ) ) ? $subscription->get_billing_email() : $subscription->billing_email;
 
-			if ( ! $subscription->billing_email ) {
+			if ( ! $billing_email ) {
 				die();
 			}
 
@@ -281,7 +282,7 @@ class WCSG_Download_Handler {
 
 			foreach ( $product_ids as $product_id ) {
 				$product = wc_get_product( $product_id );
-				$files   = $product->get_files();
+				$files   = is_callable( array( $product, 'get_downloads' ) ) ? $product->get_downloads() : $product->get_files();
 
 				if ( $files ) {
 					foreach ( $files as $download_id => $file ) {
@@ -312,6 +313,10 @@ class WCSG_Download_Handler {
 
 					self::$subscription_download_permissions[ $loop ] = $download;
 
+					if ( class_exists( 'WC_Customer_Download' ) ) {
+						// Post WC 3.0 the template expects a WC_Customer_Download object rather than stdClass objects
+						$download = new WC_Customer_Download( $download );
+					}
 					include( plugin_dir_path( WC_PLUGIN_FILE ) . 'includes/admin/meta-boxes/views/html-order-download-permission.php' );
 				}
 			}

--- a/includes/class-wcsg-download-handler.php
+++ b/includes/class-wcsg-download-handler.php
@@ -125,7 +125,7 @@ class WCSG_Download_Handler {
 
 		if ( WCS_Gifting::is_gifted_subscription( $subscription ) ) {
 
-			self::$subscription_download_permissions = self::get_subscription_download_permissions( $subscription->id );
+			self::$subscription_download_permissions = self::get_subscription_download_permissions( wcsg_get_objects_id( $subscription ) );
 		}
 	}
 
@@ -380,7 +380,7 @@ class WCSG_Download_Handler {
 			WHERE user_id = %d
 			AND order_id = %d
 			AND product_id = %d
-		", $user_id, $order->id, $product_id ) );
+		", $user_id, wcsg_get_objects_id( $order ), $product_id ) );
 
 		$files   = array();
 		$product = wc_get_product( $product_id );

--- a/includes/class-wcsg-email.php
+++ b/includes/class-wcsg-email.php
@@ -175,9 +175,11 @@ class WCSG_Email {
 			if ( isset( $item['wcsg_gift_recipients_email'] ) ) {
 				if ( $item['wcsg_gift_recipients_email'] == $new_customer_data['user_email'] ) {
 					WC()->mailer();
-					$user_password = $new_customer_data['user_pass'];
-					$current_user = wp_get_current_user();
-					$subscription_purchaser = WCS_Gifting::get_user_display_name( $current_user->ID );
+
+					$user_password          = $new_customer_data['user_pass'];
+					$current_user_id        = get_current_user_id();
+					$subscription_purchaser = WCS_Gifting::get_user_display_name( $current_user_id );
+
 					do_action( 'wcsg_created_customer_notification', $customer_id, $user_password, $subscription_purchaser );
 					break;
 				}

--- a/includes/class-wcsg-email.php
+++ b/includes/class-wcsg-email.php
@@ -115,10 +115,12 @@ class WCSG_Email {
 			WC()->mailer();
 			foreach ( $subscriptions as $subscription ) {
 				if ( WCS_Gifting::is_gifted_subscription( $subscription ) ) {
-					if ( ! in_array( $subscription->recipient_user, $processed_recipients ) ) {
-						$recipient_subscriptions = WCSG_Recipient_Management::get_recipient_subscriptions( $subscription->recipient_user, $order_id );
-						do_action( 'wcsg_new_order_recipient_notification', $subscription->recipient_user, $recipient_subscriptions );
-						array_push( $processed_recipients, $subscription->recipient_user );
+					$recipient_user_id = WCS_Gifting::get_recipient_user( $subscription );
+
+					if ( ! in_array( $recipient_user_id, $processed_recipients ) ) {
+						$recipient_subscriptions = WCSG_Recipient_Management::get_recipient_subscriptions( $recipient_user_id, $order_id );
+						do_action( 'wcsg_new_order_recipient_notification', $recipient_user_id, $recipient_subscriptions );
+						array_push( $processed_recipients, $recipient_user_id );
 					}
 				}
 			}

--- a/includes/class-wcsg-email.php
+++ b/includes/class-wcsg-email.php
@@ -221,7 +221,7 @@ class WCSG_Email {
 			return $heading;
 		}
 
-		$user_id = $order->customer_user;
+		$user_id = $order->get_user_id();
 		$mailer  = WC()->mailer();
 		$sending_email;
 

--- a/includes/class-wcsg-memberships-integration.php
+++ b/includes/class-wcsg-memberships-integration.php
@@ -61,7 +61,7 @@ class WCSG_Memberships_Integration {
 
 					if ( $plan->has_product( $product_id ) ) {
 						foreach ( $grant_access_to_recipients as $recipient_user_id ) {
-							$plan->grant_access_from_purchase( $recipient_user_id, $product_id, $order->id );
+							$plan->grant_access_from_purchase( $recipient_user_id, $product_id, wcsg_get_objects_id( $order ) );
 						}
 					}
 				}
@@ -171,7 +171,7 @@ class WCSG_Memberships_Integration {
 					return;
 				}
 
-				update_post_meta( $args['user_membership_id'], '_subscription_id', $subscription->id );
+				update_post_meta( $args['user_membership_id'], '_subscription_id', wcsg_get_objects_id( $subscription ) );
 
 				// Update the membership end date to align it to the user's subscription
 				$wcm_subscriptions_integration_instance->update_related_membership_dates( $subscription, 'end', $subscription->get_date( 'end' ) );

--- a/includes/class-wcsg-memberships-integration.php
+++ b/includes/class-wcsg-memberships-integration.php
@@ -108,7 +108,7 @@ class WCSG_Memberships_Integration {
 
 			foreach ( $order->get_items() as $order_item_id => $order_item ) {
 
-				$user_id = ( isset( $order_item['item_meta']['wcsg_recipient'] ) ) ? WCS_Gifting::get_order_item_recipient_user_id( $order_item ) : $order->customer_user;
+				$user_id = ( isset( $order_item['item_meta']['wcsg_recipient'] ) ) ? WCS_Gifting::get_order_item_recipient_user_id( $order_item ) : $order->get_user_id();
 
 				if ( in_array( $order_item['product_id'], $all_access_granting_product_ids ) ) {
 					$user_unique_product_ids[ $user_id ][] = $order_item['product_id'];
@@ -161,7 +161,7 @@ class WCSG_Memberships_Integration {
 				: wc_memberships()->get_subscriptions_integration();
 
 			// check if the member user is a recipient
-			if ( $order->user_id != $args['user_id'] ) {
+			if ( $order->get_user_id() != $args['user_id'] ) {
 				$recipient_subscriptions         = WCSG_Recipient_Management::get_recipient_subscriptions( $args['user_id'] );
 				$recipient_subscription_in_order = array_intersect( array_keys( $subscriptions_in_order ), $recipient_subscriptions );
 

--- a/includes/class-wcsg-memberships-integration.php
+++ b/includes/class-wcsg-memberships-integration.php
@@ -179,8 +179,10 @@ class WCSG_Memberships_Integration {
 			// If the member user is the purchaser, set the linked subscription to their subscription just in case
 			} else {
 				foreach ( $subscriptions_in_order as $subscription ) {
-					if ( ! isset( $subscription->recipient_user ) ) {
-						update_post_meta( $args['user_membership_id'], '_subscription_id', $subscription->id );
+					$recipient_user_id = WCS_Gifting::get_recipient_user( $subscription );
+
+					if ( empty( $recipient_user_id ) ) {
+						update_post_meta( $args['user_membership_id'], '_subscription_id', wcsg_get_objects_id( $subscription ) );
 						$wcm_subscriptions_integration_instance->update_related_membership_dates( $subscription, 'end', $subscription->get_date( 'end' ) );
 					}
 				}

--- a/includes/class-wcsg-recipient-addresses.php
+++ b/includes/class-wcsg-recipient-addresses.php
@@ -27,8 +27,9 @@ class WCSG_Recipient_Addresses {
 			if ( 'shipping' == get_query_var( 'edit-address' ) ) {
 
 				foreach ( $subscriptions as $subscription_id => $subscription ) {
+					$recipient_user_id = WCS_Gifting::get_recipient_user( $subscription );
 
-					if ( ! empty( $subscription->recipient_user ) && $subscription->recipient_user != $user_id ) {
+					if ( ! empty( $recipient_user_id ) && $recipient_user_id != $user_id ) {
 						unset( $subscriptions[ $subscription_id ] );
 					}
 				}
@@ -36,8 +37,9 @@ class WCSG_Recipient_Addresses {
 
 				// We dont want to update the billing address of gifted subscriptions for this user.
 				foreach ( $subscriptions as $subscription_id => $subscription ) {
+					$recipient_user_id = WCS_Gifting::get_recipient_user( $subscription );
 
-					if ( ! empty( $subscription->recipient_user ) && $subscription->recipient_user == $user_id ) {
+					if ( ! empty( $recipient_user_id ) && $recipient_user_id == $user_id ) {
 						unset( $subscriptions[ $subscription_id ] );
 					}
 				}

--- a/includes/class-wcsg-recipient-details.php
+++ b/includes/class-wcsg-recipient-details.php
@@ -20,8 +20,8 @@ class WCSG_Recipient_Details {
 	 */
 	public static function add_new_customer_template( $located, $template_name, $args, $template_path, $default_path ) {
 		global $wp;
-		$current_user = wp_get_current_user();
-		if ( 'true' === get_user_meta( $current_user->ID, 'wcsg_update_account', true ) ) {
+		$current_user_id = get_current_user_id();
+		if ( 'true' === get_user_meta( $current_user_id, 'wcsg_update_account', true ) ) {
 			if ( 'myaccount/my-account.php' == $template_name && isset( $wp->query_vars['new-recipient-account'] ) ) {
 				$located = wc_locate_template( 'new-recipient-account.php', $template_path, plugin_dir_path( WCS_Gifting::$plugin_file ) . 'templates/' );
 			}
@@ -34,12 +34,12 @@ class WCSG_Recipient_Details {
 	 */
 	public static function my_account_template_redirect() {
 		global $wp;
-		$current_user = wp_get_current_user();
+		$current_user_id = get_current_user_id();
 		if ( is_account_page() && ! isset( $wp->query_vars['customer-logout'] ) ) {
-			if ( 'true' === get_user_meta( $current_user->ID, 'wcsg_update_account', true )  && ! isset( $wp->query_vars['new-recipient-account'] ) ) {
+			if ( 'true' === get_user_meta( $current_user_id, 'wcsg_update_account', true )  && ! isset( $wp->query_vars['new-recipient-account'] ) ) {
 				wp_redirect( wc_get_endpoint_url( 'new-recipient-account', '', wc_get_page_permalink( 'myaccount' ) ) );
 				exit();
-			} else if ( 'true' !== get_user_meta( $current_user->ID, 'wcsg_update_account', true ) && isset( $wp->query_vars['new-recipient-account'] ) ) {
+			} else if ( 'true' !== get_user_meta( $current_user_id, 'wcsg_update_account', true ) && isset( $wp->query_vars['new-recipient-account'] ) ) {
 				wp_redirect( wc_get_page_permalink( 'myaccount' ) );
 				exit();
 			}

--- a/includes/class-wcsg-recipient-management.php
+++ b/includes/class-wcsg-recipient-management.php
@@ -191,7 +191,7 @@ class WCSG_Recipient_Management {
 		if ( WCS_Gifting::is_gifted_subscription( $subscription ) && get_current_user_id() == WCS_Gifting::get_recipient_user( $subscription ) ) {
 
 			// Make sure subscription suspension count hasn't been reached
-			$suspension_count    = $subscription->suspension_count;
+			$suspension_count    = wcsg_get_objects_property( $subscription, 'suspension_count' );
 			$allowed_suspensions = get_option( WC_Subscriptions_Admin::$option_prefix . '_max_customer_suspensions', 0 );
 
 			if ( 'unlimited' === $allowed_suspensions || $allowed_suspensions > $suspension_count ) { // 0 not > anything so prevents a customer ever being able to suspend

--- a/includes/class-wcsg-recipient-management.php
+++ b/includes/class-wcsg-recipient-management.php
@@ -265,8 +265,10 @@ class WCSG_Recipient_Management {
 	public static function maybe_remove_parent_order( $related_orders, $subscription ) {
 		if ( WCS_Gifting::is_gifted_subscription( $subscription ) && get_current_user_id() == WCS_Gifting::get_recipient_user( $subscription ) ) {
 			$related_order_ids = array_keys( $related_orders );
-			if ( in_array( $subscription->order->id, $related_order_ids ) ) {
-				unset( $related_orders[ $subscription->order->id ] );
+			$parent_order_id   = wcsg_get_objects_id( wcsg_get_objects_property( $subscription, 'order' ) );
+
+			if ( in_array( $parent_order_id, $related_order_ids ) ) {
+				unset( $related_orders[ $parent_order_id ] );
 			}
 		}
 		return $related_orders;
@@ -474,7 +476,7 @@ class WCSG_Recipient_Management {
 					foreach ( $subscriptions as $subscription_id ) {
 
 						$subscription = wcs_get_subscription( $subscription_id );
-						echo '<dd>' . esc_html__( 'Subscription' , 'woocommerce-subscriptions-gifting' ) . ' <a href="' . esc_url( wcs_get_edit_post_link( $subscription->id ) ) . '">#' . esc_html( $subscription->get_order_number() ) . '</a></dd>';
+						echo '<dd>' . esc_html__( 'Subscription' , 'woocommerce-subscriptions-gifting' ) . ' <a href="' . esc_url( wcs_get_edit_post_link( wcsg_get_objects_id( $subscription ) ) ) . '">#' . esc_html( $subscription->get_order_number() ) . '</a></dd>';
 
 					}
 				}

--- a/includes/emails/class-wcsg-email-completed-renewal-order.php
+++ b/includes/emails/class-wcsg-email-completed-renewal-order.php
@@ -33,7 +33,7 @@ class WCSG_Email_Completed_Renewal_Order extends WCS_Email_Completed_Renewal_Ord
 	/**
 	 * trigger function.
 	 */
-	function trigger( $order_id ) {
+	function trigger( $order_id, $order = null ) {
 
 		if ( $order_id ) {
 			$this->object    = wc_get_order( $order_id );

--- a/includes/emails/class-wcsg-email-completed-renewal-order.php
+++ b/includes/emails/class-wcsg-email-completed-renewal-order.php
@@ -39,7 +39,7 @@ class WCSG_Email_Completed_Renewal_Order extends WCS_Email_Completed_Renewal_Ord
 			$this->object    = wc_get_order( $order_id );
 			$subscriptions   = wcs_get_subscriptions_for_renewal_order( $order_id );
 			$subscriptions   = array_values( $subscriptions );
-			$recipient_id    = get_post_meta( $subscriptions[0]->id, '_recipient_user', true );
+			$recipient_id    = get_post_meta( wcsg_get_objects_id( $subscriptions[0] ), '_recipient_user', true );
 			$this->recipient = get_userdata( $recipient_id )->user_email;
 		}
 

--- a/includes/emails/class-wcsg-email-completed-renewal-order.php
+++ b/includes/emails/class-wcsg-email-completed-renewal-order.php
@@ -44,11 +44,14 @@ class WCSG_Email_Completed_Renewal_Order extends WCS_Email_Completed_Renewal_Ord
 		}
 
 		$order_date_index = array_search( '{order_date}', $this->find );
+		$date_format      = is_callable( 'wc_date_format' ) ? wc_date_format() : woocommerce_date_format();
+		$order_date_time  = is_callable( array( $this->object, 'get_date_created' ) ) ? $this->object->get_date_created()->getTimestamp() : strtotime( $this->object->order_date );
+
 		if ( false === $order_date_index ) {
 			$this->find[] = '{order_date}';
-			$this->replace[] = date_i18n( woocommerce_date_format(), strtotime( $this->object->order_date ) );
+			$this->replace[] = date_i18n( $date_format, $order_date_time );
 		} else {
-			$this->replace[ $order_date_index ] = date_i18n( woocommerce_date_format(), strtotime( $this->object->order_date ) );
+			$this->replace[ $order_date_index ] = date_i18n( $date_format, $order_date_time );
 		}
 
 		if ( ! $this->is_enabled() || ! $this->get_recipient() ) {

--- a/includes/emails/class-wcsg-email-processing-renewal-order.php
+++ b/includes/emails/class-wcsg-email-processing-renewal-order.php
@@ -30,7 +30,7 @@ class WCSG_Email_Processing_Renewal_Order extends WCS_Email_Processing_Renewal_O
 	/**
 	 * trigger function.
 	 */
-	function trigger( $order_id ) {
+	function trigger( $order_id, $order = null ) {
 
 		if ( $order_id ) {
 			$this->object    = wc_get_order( $order_id );

--- a/includes/emails/class-wcsg-email-processing-renewal-order.php
+++ b/includes/emails/class-wcsg-email-processing-renewal-order.php
@@ -41,11 +41,14 @@ class WCSG_Email_Processing_Renewal_Order extends WCS_Email_Processing_Renewal_O
 		}
 
 		$order_date_index = array_search( '{order_date}', $this->find );
+		$date_format      = is_callable( 'wc_date_format' ) ? wc_date_format() : woocommerce_date_format();
+		$order_date_time  = is_callable( array( $this->object, 'get_date_created' ) ) ? $this->object->get_date_created()->getTimestamp() : strtotime( $this->object->order_date );
+
 		if ( false === $order_date_index ) {
 			$this->find[] = '{order_date}';
-			$this->replace[] = date_i18n( woocommerce_date_format(), strtotime( $this->object->order_date ) );
+			$this->replace[] = date_i18n( $date_format, $order_date_time );
 		} else {
-			$this->replace[ $order_date_index ] = date_i18n( woocommerce_date_format(), strtotime( $this->object->order_date ) );
+			$this->replace[ $order_date_index ] = date_i18n( $date_format, $order_date_time );
 		}
 
 		if ( ! $this->is_enabled() || ! $this->get_recipient() ) {

--- a/includes/emails/class-wcsg-email-processing-renewal-order.php
+++ b/includes/emails/class-wcsg-email-processing-renewal-order.php
@@ -36,7 +36,7 @@ class WCSG_Email_Processing_Renewal_Order extends WCS_Email_Processing_Renewal_O
 			$this->object    = wc_get_order( $order_id );
 			$subscriptions   = wcs_get_subscriptions_for_renewal_order( $order_id );
 			$subscriptions   = array_values( $subscriptions );
-			$recipient_id    = get_post_meta( $subscriptions[0]->id, '_recipient_user', true );
+			$recipient_id    = get_post_meta( wcsg_get_objects_id( $subscriptions[0] ), '_recipient_user', true );
 			$this->recipient = get_user_by( 'id', $recipient_id )->user_email;
 		}
 

--- a/includes/emails/class-wcsg-email-recipient-new-initial-order.php
+++ b/includes/emails/class-wcsg-email-recipient-new-initial-order.php
@@ -38,7 +38,7 @@ class WCSG_Email_Recipient_New_Initial_Order extends WC_Email {
 			$this->object             = get_user_by( 'id', $recipient_user );
 			$this->recipient          = stripslashes( $this->object->user_email );
 			$subscription             = wcs_get_subscription( $recipient_subscriptions[0] );
-			$this->subscription_owner = WCS_Gifting::get_user_display_name( $subscription->customer_user );
+			$this->subscription_owner = WCS_Gifting::get_user_display_name( $subscription->get_user_id() );
 			$this->subscriptions      = $recipient_subscriptions;
 		}
 

--- a/includes/wcsg-compatibility-functions.php
+++ b/includes/wcsg-compatibility-functions.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * WooCommerce Compatibility functions
+ *
+ * Functions to take advantage of APIs added to new versions of WooCommerce while maintaining backward compatibility.
+ *
+ * @author   Prospress
+ * @category Core
+ * @package  WooCommerce Subscriptions Gifting/Functions
+ * @version  1.0.1
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly
+}
+
+/**
+ * Check if the installed version of WooCommerce is older than a specified version.
+ *
+ * @param string $version
+ * @return bool
+ * @since 1.0.1
+ */
+function wcsg_is_woocommerce_pre( $version ) {
+
+	if ( ! defined( 'WC_VERSION' ) || version_compare( WC_VERSION, $version, '<' ) ) {
+		$woocommerce_is_pre_version = true;
+	} else {
+		$woocommerce_is_pre_version = false;
+	}
+
+	return $woocommerce_is_pre_version;
+}
+
+/**
+ * Get an object's property value in a version compatible way.
+ *
+ * @param object $object WC_Order|WC_Subscription|WC_Product etc
+ * @param string property name
+ * @return mixed
+ * @since 1.0.1
+ */
+function wcsg_get_objects_property( $object, $property ) {
+	$value = '';
+
+	switch ( $property ) {
+		case 'order':
+			if ( is_callable( array( $object, 'get_parent' ) ) ) {
+				$value = $object->get_parent();
+			} else {
+				$value = $object->order;
+			}
+			break;
+		default:
+			$function = 'get_' . $property;
+
+			if ( is_callable( array( $object, $function ) ) ) {
+				$value = $object->$function();
+			} else {
+				$value = $object->$property;
+			}
+			break;
+	}
+
+	return $value;
+
+}
+
+/**
+ * Get an object's ID in a version compatible way.
+ *
+ * @param object $object WC_Order|WC_Subscription|WC_Product etc
+ * @return int
+ * @since 1.0.1
+ */
+function wcsg_get_objects_id( $object ) {
+
+	if ( method_exists( $object, 'get_id' ) ) {
+		$id = $object->get_id();
+	} else {
+		$id = $object->id;
+	}
+
+	return $id;
+}

--- a/templates/new-recipient-account.php
+++ b/templates/new-recipient-account.php
@@ -28,7 +28,7 @@ foreach ( $form_fields as $key => $field ) {
 wp_nonce_field( 'wcsg_new_recipient_data', '_wcsgnonce' );
 
 ?>
-<input type="hidden" name="wcsg_new_recipient_customer" value="<?php echo esc_attr( wp_get_current_user()->ID ); ?>" />
+<input type="hidden" name="wcsg_new_recipient_customer" value="<?php echo esc_attr( get_current_user_id() ); ?>" />
 <input type="submit" class="button" name="save_address" value="<?php esc_html_e( 'Save', 'woocommerce-subscriptions-gifting' ); ?>" />
 
 </form>

--- a/templates/related-orders.php
+++ b/templates/related-orders.php
@@ -17,7 +17,7 @@
 	<tbody>
 		<?php foreach ( $subscription_orders as $subscription_order ) {
 			$order        = wc_get_order( $subscription_order );
-			$display_link = current_user_can( 'view_order', $order->id );
+			$display_link = current_user_can( 'view_order', wcsg_get_objects_id( $order ) );
 			$item_count = $order->get_item_count();
 			?><tr class="order">
 				<td class="order-number" data-title="<?php esc_attr_e( 'Order Number', 'woocommerce-subscriptions-gifting' ); ?>">

--- a/templates/related-orders.php
+++ b/templates/related-orders.php
@@ -19,6 +19,14 @@
 			$order        = wc_get_order( $subscription_order );
 			$display_link = current_user_can( 'view_order', wcsg_get_objects_id( $order ) );
 			$item_count = $order->get_item_count();
+
+			if ( wcsg_is_woocommerce_pre( '3.0' ) ) {
+				$order_date = $order->order_date;
+			} else {
+				$order_date = $order->get_date_created();
+				$order_date->format( 'Y-m-d H:i:s' );
+			}
+
 			?><tr class="order">
 				<td class="order-number" data-title="<?php esc_attr_e( 'Order Number', 'woocommerce-subscriptions-gifting' ); ?>">
 					<?php if ( $display_link ) : ?>
@@ -30,7 +38,7 @@
 					<?php endif; ?>
 				</td>
 				<td class="order-date" data-title="<?php esc_attr_e( 'Date', 'woocommerce-subscriptions-gifting' ); ?>">
-					<time datetime="<?php echo esc_attr( date( 'Y-m-d', strtotime( $order->order_date ) ) ); ?>" title="<?php echo esc_attr( strtotime( $order->order_date ) ); ?>"><?php echo wp_kses_post( date_i18n( get_option( 'date_format' ), strtotime( $order->order_date ) ) ); ?></time>
+					<time datetime="<?php echo esc_attr( date( 'Y-m-d', strtotime( $order_date ) ) ); ?>" title="<?php echo esc_attr( strtotime( $order_date ) ); ?>"><?php echo wp_kses_post( date_i18n( get_option( 'date_format' ), strtotime( $order_date ) ) ); ?></time>
 				</td>
 				<td class="order-status" data-title="<?php esc_attr_e( 'Status', 'woocommerce-subscriptions-gifting' ); ?>" style="text-align:left; white-space:nowrap;">
 					<?php

--- a/templates/related-orders.php
+++ b/templates/related-orders.php
@@ -36,7 +36,7 @@
 					<?php
 					echo esc_html( wc_get_order_status_name( $order->get_status() ) );
 					if ( ! in_array( $order->get_status(), apply_filters( 'woocommerce_valid_order_statuses_for_payment', array( 'pending', 'failed' ), $order ) ) ) {
-						if ( wp_get_current_user()->ID != $order->get_user_id() ) {
+						if ( get_current_user_id() != $order->get_user_id() ) {
 							echo '</br><small>' . esc_html( 'Purchased by ' . $order->get_user()->display_name ) . '</small>';
 						}
 					}

--- a/tests/unit/wcsg-renewal-order-tests.php
+++ b/tests/unit/wcsg-renewal-order-tests.php
@@ -115,7 +115,7 @@ class WCSG_Renewal_Order_Tests extends WC_Unit_Test_Case {
 
 		add_filter( 'woocommerce_subscription_is_purchasable', '__return_true' );
 
-		WC()->cart->add_to_cart( $product->id, 1, '', array(), array( 'subscription_renewal' => array( 'subscription_id' => $subscription->id ) ) );
+		WC()->cart->add_to_cart( $product->id, 1, '', array(), array( 'subscription_renewal' => array( 'subscription_id' => wcsg_get_objects_id( $subscription ) ) ) );
 
 		remove_filter( 'woocommerce_subscription_is_purchasable', '__return_true' );
 	}
@@ -127,8 +127,8 @@ class WCSG_Renewal_Order_Tests extends WC_Unit_Test_Case {
 
 		parent::tearDown();
 
-		wp_delete_post( $this->subscription->id, true );
-		wp_delete_post( $this->gifted_subscription->id, true );
+		wp_delete_post( wcsg_get_objects_id( $this->subscription ), true );
+		wp_delete_post( wcsg_get_objects_id( $this->gifted_subscription ), true );
 		wp_delete_post( $this->subscription_product->id, true );
 
 		wp_delete_user( $this->recipient_user );

--- a/woocommerce-subscriptions-gifting.php
+++ b/woocommerce-subscriptions-gifting.php
@@ -68,6 +68,8 @@ require_once( 'includes/class-wcsg-admin.php' );
 
 require_once( 'includes/class-wcsg-recipient-addresses.php' );
 
+require_once( 'includes/wcsg-compatibility-functions.php' );
+
 class WCS_Gifting {
 
 	public static $plugin_file = __FILE__;

--- a/woocommerce-subscriptions-gifting.php
+++ b/woocommerce-subscriptions-gifting.php
@@ -405,12 +405,18 @@ class WCS_Gifting {
 	 * @return bool
 	 */
 	public static function is_gifted_subscription( $subscription ) {
+		$is_gifted_subscription = false;
 
 		if ( ! $subscription instanceof WC_Subscription ) {
 			$subscription = wcs_get_subscription( $subscription );
 		}
 
-		return wcs_is_subscription( $subscription ) && ! empty( $subscription->recipient_user ) && is_numeric( $subscription->recipient_user );
+		if ( wcs_is_subscription( $subscription ) ) {
+			$recipient_user_id      = self::get_recipient_user( $subscription );
+			$is_gifted_subscription = ! empty( $recipient_user_id ) && is_numeric( $recipient_user_id );
+		}
+
+		return $is_gifted_subscription;
 	}
 
 	/**
@@ -494,5 +500,24 @@ class WCS_Gifting {
 		return ( isset( $order_item['item_meta']['wcsg_recipient'] ) ) ? substr( $order_item['item_meta']['wcsg_recipient'][0], strlen( 'wcsg_recipient_id_' ) ) : false;
 	}
 
+	/**
+	 * Retrieve the recipient user ID from a subscription
+	 *
+	 * @param WC_Subscription $subscription
+	 * @return string $recipient_user_id the recipient's user ID. returns an empty string if there is no recipient set.
+	 */
+	public static function get_recipient_user( $subscription ) {
+		$recipient_user_id = '';
+
+		if ( method_exists( $subscription, 'get_meta' ) ) {
+			if ( $subscription->meta_exists( '_recipient_user' ) ) {
+				$recipient_user_id = $subscription->get_meta( '_recipient_user' );
+			}
+		} else { // WC < 3.0
+			$recipient_user_id = $subscription->recipient_user;
+		}
+
+		return $recipient_user_id;
+	}
 }
 WCS_Gifting::init();

--- a/woocommerce-subscriptions-gifting.php
+++ b/woocommerce-subscriptions-gifting.php
@@ -499,7 +499,14 @@ class WCS_Gifting {
 	 * @return mixed bool|int The recipient user id or false if the order item is not gifted
 	 */
 	public static function get_order_item_recipient_user_id( $order_item ) {
-		return ( isset( $order_item['item_meta']['wcsg_recipient'] ) ) ? substr( $order_item['item_meta']['wcsg_recipient'][0], strlen( 'wcsg_recipient_id_' ) ) : false;
+
+		if ( is_a( $order_item, 'WC_Order_Item' ) && $order_item->meta_exists( 'wcsg_recipient' ) ) {
+			$raw_recipient_meta = $order_item->get_meta( 'wcsg_recipient' );
+		} elseif ( isset( $order_item['item_meta']['wcsg_recipient'] ) ) {
+			$raw_recipient_meta = $order_item['item_meta']['wcsg_recipient'][0];
+		}
+
+		return isset( $raw_recipient_meta ) ? substr( $raw_recipient_meta, strlen( 'wcsg_recipient_id_' ) ) : false;
 	}
 
 	/**

--- a/woocommerce-subscriptions-gifting.php
+++ b/woocommerce-subscriptions-gifting.php
@@ -503,6 +503,32 @@ class WCS_Gifting {
 	}
 
 	/**
+	 * Create a recipient user account.
+	 *
+	 * @param string $recipient_email
+	 * @return int $recipient_user_id
+	 */
+	public static function create_recipient_user( $recipient_email ) {
+		$username = explode( '@', $recipient_email );
+		$username = sanitize_user( $username[0], true );
+		$counter  = 1;
+
+		$original_username = $username;
+
+		while ( username_exists( $username ) ) {
+			$username = $original_username . $counter;
+			$counter++;
+		}
+
+		$password = wp_generate_password();
+		$recipient_user_id = wc_create_new_customer( $recipient_email, $username, $password );
+
+		// set a flag to force the user to update/set account information on login
+		update_user_meta( $recipient_user_id, 'wcsg_update_account', 'true' );
+		return $recipient_user_id;
+	}
+
+	/**
 	 * Retrieve the recipient user ID from a subscription
 	 *
 	 * @param WC_Subscription $subscription


### PR DESCRIPTION
This PR introduces the changes needed to be compatible with WC 3.0. 

See https://github.com/Prospress/woocommerce-subscriptions-gifting/issues/203#issuecomment-319263117 for the functionality I've tested. 

The changes are largely made up of replacing direct order/subscription property access with helper functions. 

Other changes are due to deprecated action hooks, and functions and general changes in the way WC core does things. 