### PR TITLE
Remove recipient line item meta from order again cart item meta

### DIFF
--- a/includes/class-wcsg-cart.php
+++ b/includes/class-wcsg-cart.php
@@ -14,6 +14,8 @@ class WCSG_Cart {
 		add_filter( 'woocommerce_add_to_cart_validation', __CLASS__ . '::prevent_products_in_gifted_renewal_orders', 10 );
 
 		add_filter( 'woocommerce_order_again_cart_item_data', __CLASS__ . '::add_recipient_to_resubscribe_initial_payment_item', 10, 3 );
+
+		add_filter( 'woocommerce_order_again_cart_item_data', __CLASS__ . '::remove_recipient_from_order_again_cart_item_meta', 10, 1 );
 	}
 
 	/**
@@ -230,6 +232,25 @@ class WCSG_Cart {
 		}
 
 		return $recipient_user_id;
+	}
+
+	/**
+	 * Remove recipient line item meta from order again cart item meta. This meta is re-added to the line item after
+	 * checkout and so doesn't need to copied through the cart in this way.
+	 *
+	 * @param array $cart_item_data
+	 * @return array $cart_item_data
+	 * @since 1.0.1
+	 */
+	public static function remove_recipient_from_order_again_cart_item_meta( $cart_item_data ) {
+
+		foreach ( array( 'subscription_renewal', 'subscription_resubscribe', 'subscription_initial_payment' ) as $subscription_order_again_key ) {
+			if ( isset( $cart_item_data[ $subscription_order_again_key ]['custom_line_item_meta']['wcsg_recipient'] ) ) {
+				unset( $cart_item_data[ $subscription_order_again_key ]['custom_line_item_meta']['wcsg_recipient'] );
+			}
+		}
+
+		return $cart_item_data;
 	}
 }
 WCSG_Cart::init();


### PR DESCRIPTION
To replicate with the latest Subscriptions version (`2.2.11`+):

- Create a [pending renewal](https://docs.woocommerce.com/document/subscriptions/add-or-modify-a-subscription/#section-13) order for a gifted subscription
- Place the renewal order in the cart by clicking "Pay" from the customer's My Account page or following the pay link on the edit order screen.
![screen_shot_2017-08-03_at_5_01_51_pm](https://user-images.githubusercontent.com/8490476/28909907-cec1b284-786d-11e7-9c7b-a0136f8d86ce.png)

If you check out at this point the meta is doubled up (eg https://cloudup.com/cdg4ukf7l7q).

Because we already copy the recipient information into the cart when the customer resubscribes/manually renews it doesn't need to be copied through the cart in this way by Subscriptions core.

fixes #210 