### PR TITLE
Reload checkout after making a change to a recipient - fixes issues with incorrect shipping selection

### DIFF
--- a/includes/class-wcsg-checkout.php
+++ b/includes/class-wcsg-checkout.php
@@ -163,6 +163,12 @@ class WCSG_Checkout {
 		parse_str( $checkout_data, $checkout_data );
 
 		if ( isset( $checkout_data['recipient_email'] ) ) {
+			foreach ( WC()->cart->cart_contents as $key => $item ) {
+				if ( isset( $checkout_data['recipient_email'][ $key ] ) ) {
+					WCS_Gifting::update_cart_item_key( $item, $key, $checkout_data['recipient_email'][ $key ] );
+				}
+			}
+
 			WC()->session->set( 'wcsg_recipients', $checkout_data['recipient_email'] );
 		}
 	}

--- a/includes/class-wcsg-checkout.php
+++ b/includes/class-wcsg-checkout.php
@@ -32,16 +32,6 @@ class WCSG_Checkout {
 	 * @return int|quantity The quantity of the cart item with ui elements appended on
 	 */
 	public static function add_gifting_option_checkout( $quantity, $cart_item, $cart_item_key ) {
-
-		$recipients = WC()->session->get( 'wcsg_recipients' );
-
-		if ( ! empty( $recipients ) && isset( $recipients[ $cart_item_key ] ) ) {
-			$cart_item['wcsg_gift_recipients_email'] = $recipients[ $cart_item_key ];
-
-			unset( $recipients[ $cart_item_key ] );
-			WC()->session->set( 'wcsg_recipients', $recipients );
-		}
-
 		return $quantity . WCSG_Cart::maybe_display_gifting_information( $cart_item, $cart_item_key );
 	}
 
@@ -163,13 +153,12 @@ class WCSG_Checkout {
 		parse_str( $checkout_data, $checkout_data );
 
 		if ( isset( $checkout_data['recipient_email'] ) ) {
+			// Store recipient emails on the cart items so they can be repopulated after checkout update
 			foreach ( WC()->cart->cart_contents as $key => $item ) {
 				if ( isset( $checkout_data['recipient_email'][ $key ] ) ) {
 					WCS_Gifting::update_cart_item_key( $item, $key, $checkout_data['recipient_email'][ $key ] );
 				}
 			}
-
-			WC()->session->set( 'wcsg_recipients', $checkout_data['recipient_email'] );
 		}
 	}
 

--- a/js/wcs-gifting.js
+++ b/js/wcs-gifting.js
@@ -4,7 +4,14 @@ jQuery(document).ready(function($){
 			$(this).siblings('.woocommerce_subscriptions_gifting_recipient_email').slideDown( 250 );
 		} else {
 			$(this).siblings('.woocommerce_subscriptions_gifting_recipient_email').slideUp( 250 );
-			$(this).parent().find('.recipient_email').val('');
+
+			var recipient_email_element = $(this).parent().find('.recipient_email');
+			recipient_email_element.val('');
+
+			if ( $( 'form.checkout' ).length !== 0 ) {
+				// Trigger the event to update the checkout after the recipient field has been cleared
+				recipient_email_element.trigger( 'focusout' );
+			}
 		}
 	});
 
@@ -24,7 +31,12 @@ jQuery(document).ready(function($){
 		}
 	});
 
-	$(document).on( 'focusout', '.recipient_email',function() {
+	/*******************************************
+	 * Update checkout on input changed events *
+	 *******************************************/
+	var update_timer;
+
+	$(document).on( 'focusout', '.recipient_email', function() {
 
 		if ( $( 'form.checkout' ).length === 0 ) {
 			return;
@@ -33,9 +45,28 @@ jQuery(document).ready(function($){
 		var new_recipient_email      = $( this ).val();
 		var existing_recipient_email = $( this ).prop( "defaultValue" );
 
-		// if the recipient has changed, update the checkout so recurring carts are updated
+		// If the recipient has changed, update the checkout so recurring carts are updated
 		if ( new_recipient_email !== existing_recipient_email ) {
-			$( document.body ).trigger( 'update_checkout' );
+			update_checkout();
 		}
 	});
+
+	$(document).on( 'keydown', '.recipient_email', function( e ) {
+		var code = e.keyCode || e.which || 0;
+
+		if ( code === 9 ) {
+			return true;
+		}
+
+		reset_checkout_update_timer();
+		update_timer = setTimeout( update_checkout, '1500' );
+	});
+
+	function update_checkout() {
+		$( document.body ).trigger( 'update_checkout' );
+	}
+
+	function reset_checkout_update_timer() {
+		clearTimeout( update_timer );
+	}
 });

--- a/js/wcs-gifting.js
+++ b/js/wcs-gifting.js
@@ -23,4 +23,19 @@ jQuery(document).ready(function($){
 			 $( 'input[type=submit][name=update_cart]').attr( 'clicked', 'true' );
 		}
 	});
+
+	$(document).on( 'focusout', '.recipient_email',function() {
+
+		if ( $( 'form.checkout' ).length === 0 ) {
+			return;
+		}
+
+		var new_recipient_email      = $( this ).val();
+		var existing_recipient_email = $( this ).prop( "defaultValue" );
+
+		// if the recipient has changed, update the checkout so recurring carts are updated
+		if ( new_recipient_email !== existing_recipient_email ) {
+			$( document.body ).trigger( 'update_checkout' );
+		}
+	});
 });

--- a/js/wcs-gifting.js
+++ b/js/wcs-gifting.js
@@ -10,7 +10,7 @@ jQuery(document).ready(function($){
 
 			if ( $( 'form.checkout' ).length !== 0 ) {
 				// Trigger the event to update the checkout after the recipient field has been cleared
-				recipient_email_element.trigger( 'focusout' );
+				update_checkout();
 			}
 		}
 	});
@@ -36,33 +36,41 @@ jQuery(document).ready(function($){
 	 *******************************************/
 	var update_timer;
 
-	$(document).on( 'focusout', '.recipient_email', function() {
+	$(document).on( 'change', '.recipient_email', function() {
 
 		if ( $( 'form.checkout' ).length === 0 ) {
 			return;
 		}
 
-		var new_recipient_email      = $( this ).val();
-		var existing_recipient_email = $( this ).prop( "defaultValue" );
-
-		// If the recipient has changed, update the checkout so recurring carts are updated
-		if ( new_recipient_email !== existing_recipient_email ) {
+		// Update the checkout so recurring carts are updated
+		if ( $( this ).hasClass( 'wcsg_needs_update' ) ) {
 			update_checkout();
 		}
 	});
 
-	$(document).on( 'keydown', '.recipient_email', function( e ) {
+	$(document).on( 'keyup', '.recipient_email', function( e ) {
 		var code = e.keyCode || e.which || 0;
 
-		if ( code === 9 ) {
+		if ( $( 'form.checkout' ).length === 0 || code === 9 ) {
 			return true;
 		}
 
+		var current_recipient  = $( this ).val();
+		var original_recipient = $( this ).attr( 'data-recipient' );
 		reset_checkout_update_timer();
-		update_timer = setTimeout( update_checkout, '1500' );
+
+		// If the recipient has changed since last load, mark the element as needing an update
+		if ( current_recipient !== original_recipient ) {
+			$( this ).addClass( 'wcsg_needs_update' );
+			update_timer = setTimeout( update_checkout, '1500' );
+		} else {
+			$( this ).removeClass( 'wcsg_needs_update' );
+		}
 	});
 
 	function update_checkout() {
+		reset_checkout_update_timer();
+		$( '.recipient_email' ).removeClass( 'wcsg_needs_update' );
 		$( document.body ).trigger( 'update_checkout' );
 	}
 

--- a/templates/html-add-recipient.php
+++ b/templates/html-add-recipient.php
@@ -7,7 +7,7 @@
 		<label for="recipient_email[<?php echo esc_attr( $id ); ?>]">
 			<?php esc_html_e( "Recipient's Email Address:", 'woocommerce-subscriptions-gifting' ); ?>
 		</label>
-		<input type="email" class="input-text recipient_email" name="recipient_email[<?php echo esc_attr( $id ); ?>]" id="recipient_email[<?php echo esc_attr( $id ); ?>]" placeholder="<?php echo esc_attr( $email_field_args['placeholder'] ); ?>" value="<?php echo esc_attr( $email ); ?>"/>
+		<input data-recipient="<?php echo esc_attr( $email ); ?>" type="email" class="input-text recipient_email" name="recipient_email[<?php echo esc_attr( $id ); ?>]" id="recipient_email[<?php echo esc_attr( $id ); ?>]" placeholder="<?php echo esc_attr( $email_field_args['placeholder'] ); ?>" value="<?php echo esc_attr( $email ); ?>"/>
 		<?php wp_nonce_field( 'wcsg_add_recipient', '_wcsgnonce' ); ?>
 	</p>
 </fieldset>


### PR DESCRIPTION
See #209 for issue description. 

To replicate: 
- place a couple of different subscription products with the same billing schedule into the cart
- navigate to the checkout page and enter a recipient and attempt to checkout. 

You should receive an error similar to:

```
PHP Notice:  Undefined index: 2017_09_01_monthly_username@example.com_0 in /wp-content/plugins/woocommerce-subscriptions/includes/class-wc-subscriptions-cart.php on line 1119
```

The issue is caused by a change in the recipient (which updates the recurring cart key) before the checkout is validated. Subscriptions expects to find a selected shipping method of each recurring cart and because the keys have changed, it doesn't exist. This issue is even more problematic when entering a recipient or changing a recipient leads to different shipping terms.

This PR fixes that by reloading the order review section on checkout after the customer makes a change to a recipient field. This is similar to how WC core updates shipping options after changes to address fields.

The checkout is reloaded when: 
- one of the recipient email fields loses focus only if the email has changed
- 1.5 seconds after the last `keydown` event (countdown resets after each `keydown`)
- one of the checkboxes is unchecked

Example below:
![gif](https://cldup.com/cGsI0pyBkp.gif)