### PR TITLE
Fix for issue_218 - Make 'Recipient' item meta label translatable

### DIFF
--- a/includes/class-wcsg-recipient-management.php
+++ b/includes/class-wcsg-recipient-management.php
@@ -314,7 +314,7 @@ class WCSG_Recipient_Management {
 	 */
 	public static function format_recipient_meta_label( $label, $name ) {
 		if ( 'wcsg_recipient' == $name || 'wcsg_deleted_recipient_data' == $name ) {
-			$label = 'Recipient';
+			$label = __('Recipient', 'woocommerce-subscriptions-gifting');
 		}
 		return $label;
 	}

--- a/languages/woocommerce-subscriptions-gifting.pot
+++ b/languages/woocommerce-subscriptions-gifting.pot
@@ -162,6 +162,10 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
+#: includes/class-wcsg-recipient-management.php:317
+msgid "Recipient"
+msgstr ""
+
 #: includes/class-wcsg-recipient-management.php:463
 msgid "WARNING:"
 msgstr ""


### PR DESCRIPTION
## Description

If you purchase a gift product, "Recipient" label is displayed as its item meta label on 'Order received', 'My Account>Subscripitons>[Subscription]' pages and the related emails. This label is not translatable.

## Steps to replicate

1. Fresh WP install + WooCommerce + WooCommerce Subscriptions + WooCommerce Subscriptions Gifting
2. Go to Settings>General and change your site language to something different than English
3. Make sure all strings are translated in woocommerce-subscriptions-gifting_LOCALE.po/mo files
4. Open a product page in the Frontend
5. Make it a gift, specifying a recipient
6. Place the order
7. Check if "Recipient" label is translated in "Order received" page
8. Check if "Recipient" label is translated in "My Account>Subscripitons>[Subscription]" page
9. Check if "Recipient" label is translated in the received emails

## Result
"Recipient" item meta label is not translated