### PR TITLE
Fix for issue_220 - "View" button in My Account>Subscripitons>[Subscription] (related orders) is not translated

### DIFF
--- a/languages/woocommerce-subscriptions-gifting.pot
+++ b/languages/woocommerce-subscriptions-gifting.pot
@@ -433,6 +433,11 @@ msgid_plural "%1$s for %2$s items"
 msgstr[0] ""
 msgstr[1] ""
 
+#: templates/related-orders.php:78
+msgctxt "view a subscription"
+msgid "View"
+msgstr ""
+
 #: woocommerce-subscriptions-gifting.php:178
 msgid "Please enter someone else's email address."
 msgstr ""


### PR DESCRIPTION
As described on issue #220, "View" button in My Account>Subscripitons>[Subscription] (related orders) is not translated.

## Description
If you purchase a gift product and check the subscription at 'My Account>Subscripitons>[Subscription]', "View" button in "Related orders" section is not translated (it is translated in non-gifted subscriptions).

## Steps to replicate
1. Fresh WP install + WooCommerce + WooCommerce Subscriptions + WooCommerce Subscriptions Gifting
2. Go to Settings>General and change your site language to something different than English
3. Make sure all strings are translated in woocommerce-subscriptions-gifting_LOCALE.po/mo files
4. Open a product page in the Frontend
5. Make it a gift, specifying a recipient
6. Place the order
7. Check if "View" button is translated in "My Account>Subscripitons>[Subscription]" page

## Result
"View" button in "Related orders" section is not translated

## Fix 
Add the proper string in pot file (including context)

Fixes #220 