### PR TITLE
Don't reformat email subjects and headings post WC 3.1

### DIFF
--- a/includes/class-wcsg-recipient-management.php
+++ b/includes/class-wcsg-recipient-management.php
@@ -314,7 +314,7 @@ class WCSG_Recipient_Management {
 	 */
 	public static function format_recipient_meta_label( $label, $name ) {
 		if ( 'wcsg_recipient' == $name || 'wcsg_deleted_recipient_data' == $name ) {
-			$label = __('Recipient', 'woocommerce-subscriptions-gifting');
+			$label = __( 'Recipient', 'woocommerce-subscriptions-gifting' );
 		}
 		return $label;
 	}


### PR DESCRIPTION
WC 3.1 removed the dynamic email headings and subjects for emails which contained download links. 

In order for the correct headings to be sent to recipients and purchasers, Gifting would determine whether the email recipient had downloads and if they didn't, would use the `$email->heading` or `$email->subject` values to get the default heading/subject. These properties were removed (are now null) and using those properties [here](https://github.com/Prospress/woocommerce-subscriptions-gifting/blob/master/includes/class-wcsg-email.php#L245) caused blank email subjects to be returned.

This commit completely removes that process for sites running 3.1 + as it's no longer necessary.

**To replicate:**
WooCommerce: `3.1+`
WCS Gifting: `master`

1. Make sure dual download permissions are disabled from WooCommerce > Settings > Subscriptions (tab) (https://cloudup.com/c5ZYcl5aukt)
2. Create a subscription product which is downloadable and virtual with downloadable files
3. Purchase the product entering a recipient email during the cart/checkout process

Once the order is complete you should receive an email sent to the purchaser with a blank subject and heading eg: 

![86rfubycyp](https://user-images.githubusercontent.com/8490476/31373574-f03e08cc-addd-11e7-97ec-f34e10cffc0d.png). 

fixes #226 