### PR TITLE
Fix for issue_230 - Errors in language (.pot) file

### DIFF
--- a/languages/woocommerce-subscriptions-gifting.pot
+++ b/languages/woocommerce-subscriptions-gifting.pot
@@ -162,10 +162,6 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: includes/class-wcsg-recipient-management.php:317
-msgid "Recipient"
-msgstr ""
-
 #: includes/class-wcsg-recipient-management.php:463
 msgid "WARNING:"
 msgstr ""


### PR DESCRIPTION
## Description

Some errors appear when opening the languages/woocommerce-subscriptions-gifting.pot file in poEdit (or in translation plugins like LocoTranslate)

## Steps to replicate

1. Open poEdit
2. Click Archive>New Catalog from POT file and select languages/woocommerce-subscriptions-gifting.pot file
[Some errors appear]

## Fix
I've checked the pot file and I see that "Recipient" string is defined more than once in languages/woocommerce-subscriptions-gifting.pot generating some errors when processing the language file. This seems to be the origin of the conflict. 

I see that the string is from different lines in our code but I understand that we want to use the same translation for both. If for some reason we need to differentiate them, we should consider adding some context to them. 
