### PR TITLE
Only attach callbacks & call functions necessary to the WCSG query class

### DIFF
--- a/includes/class-wcsg-query.php
+++ b/includes/class-wcsg-query.php
@@ -11,11 +11,16 @@ class WCSG_Query extends WCS_Query {
 	 */
 	public function __construct() {
 
-		parent::__construct();
+		add_action( 'init', array( $this, 'add_endpoints' ) );
+
+		add_filter( 'the_title', array( $this, 'change_endpoint_title' ), 11, 1 );
 
 		if ( ! is_admin() ) {
 			add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
+			add_filter( 'woocommerce_get_breadcrumb', array( $this, 'add_breadcrumb' ), 10 );
 		}
+
+		$this->init_query_vars();
 	}
 
 	/**


### PR DESCRIPTION
Removes the call to the `WCS_Query::__construct()` which was duplicating all the callbacks attached in that class and leading to two sets of Subscription endpoints being added among other duplicate calls weren't breaking things but were unnecessary. 

I've replaced the call to `WCS_Query::__construct()` by calling `init_query_vars()` directly and attaching the hooks necessary to get the `new-recipient-account` endpoint working.

To replicate:

1. Checkout the latest WCS `master`
2. Navigate to the **WooCommce -> Settings -> Accounts**
3. Scroll down to the endpoints and you should see 2 copies of the Subscription endpoints. eg. https://cloudup.com/cp20GyxcCSp

This PR fixes that but to test that this hasn't broken the WCSG `new-recipient-account`:

1. Place a subscription in the cart.
2. Enter a recipient' email. Note the email must not already be linked to a site user.
3. Complete the checkout. 
4. The recipient should receive an email containing a link to the Account Details page or,
5. You can also access the page directly without the email by logging into the recipient's account and navigating to the My Account Page. _Go to the recipient's edit user screen on the WP dashboard to get their password_.

Once you login you should be redirected to the **Account Details** page which should look something like this: https://cloudup.com/cRVxX1SE-bZ

fixes #247 