### PR TITLE
Some changes to initialization and dependency checking

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -62,6 +62,7 @@ class WCS_Unit_Tests_Bootstrap {
 
 		// load WooCommerce Subscriptions Gifting
 		require_once( $this->plugin_dir . '/woocommerce-subscriptions-gifting.php' );
+		wcsg_load();		
 	}
 
 	/**

--- a/woocommerce-subscriptions-gifting.php
+++ b/woocommerce-subscriptions-gifting.php
@@ -307,7 +307,7 @@ class WCS_Gifting {
 			self::output_plugin_dependency_notice( 'WooCommerce', WCS_Gifting::$wc_minimum_supported_version );
 		}
 
-		if ( ! class_exists( 'WC_Subscriptions' ) ) {
+		if ( ! class_exists( 'WC_Subscription' ) ) {
 			self::output_plugin_dependency_notice( 'WooCommerce Subscriptions' );
 		} else if ( version_compare( get_option( 'woocommerce_subscriptions_active_version' ), WCS_Gifting::$wcs_minimum_supported_version, '<' ) ) {
 			self::output_plugin_dependency_notice( 'WooCommerce Subscriptions', WCS_Gifting::$wcs_minimum_supported_version );
@@ -609,7 +609,7 @@ function wcsg_load() {
 		return;
 	}
 
-	if ( ! class_exists( 'WC_Subscriptions' ) || version_compare( get_option( 'woocommerce_subscriptions_active_version' ), WCS_Gifting::$wcs_minimum_supported_version, '<' ) ) {
+	if ( ! class_exists( 'WC_Subscription' ) || version_compare( get_option( 'woocommerce_subscriptions_active_version' ), WCS_Gifting::$wcs_minimum_supported_version, '<' ) ) {
 		add_action( 'admin_notices', 'WCS_Gifting::plugin_dependency_notices' );
 		return;
 	}


### PR DESCRIPTION
This PR is inspired by #178 and #235, where some initialization issues were found to happen under certain circumstances. I tried to keep the changes to a minimum as to not break anything but at the same time address the following issues:

- Because our checks were occurring outside of any WP hook, we were implicitly relying on the default WP load order for plugins for things to work. And this does work most of the time, but it's not really reliable. For example, a minor change to the name of a plugin folder can break things. I moved initialization to `plugins_loaded`, where we can at least be certain that the classes we need have been included.
- If WooCommerce Subscriptions was disabled (but WooCommerce enabled), a call to `is_woocommerce_active()` (which is provided by WCS) resulted in a fatal error. We could've re-implemented this function inside Gifting, but if the new checks work equally fine, we might be able to save some code.
- Checking for specific classes instead of using `is_plugin_active()` also means we no longer need to include the `plugin.php` file from the admin. This is the change I have more doubts of: was there a reason for checking that specific plugins were active (by exact filename) instead of checking for the classes we need?
