### PR TITLE
Check billing e-mail address doesn't match recipient's e-mail address

### DIFF
--- a/woocommerce-subscriptions-gifting.php
+++ b/woocommerce-subscriptions-gifting.php
@@ -138,8 +138,11 @@ class WCS_Gifting {
 	 * @return bool Returns whether the email address belongs to the current user.
 	 */
 	public static function email_belongs_to_current_user( $email ) {
-		$current_user_email = wp_get_current_user()->user_email;
-		return $current_user_email == $email;
+		$current_user  = wp_get_current_user();
+		$user_email    = $current_user->user_email;
+		$billing_email = $current_user->billing_email;
+
+		return ( $user_email == $email || $billing_email == $email );
 	}
 
 	/**


### PR DESCRIPTION
This as to prevent self-gifting, as described in #234.