### PR TITLE
Updating script enqueueing to shift js to footer.

### DIFF
--- a/woocommerce-subscriptions-gifting.php
+++ b/woocommerce-subscriptions-gifting.php
@@ -128,7 +128,7 @@ class WCS_Gifting {
 	 * Register/queue frontend scripts.
 	 */
 	public static function gifting_scripts() {
-		wp_register_script( 'woocommerce_subscriptions_gifting', plugins_url( '/js/wcs-gifting.js', __FILE__ ), array( 'jquery' ) );
+		wp_register_script( 'woocommerce_subscriptions_gifting', plugins_url( '/js/wcs-gifting.js', __FILE__ ), array( 'jquery' ), '2.0.0', true );
 		wp_enqueue_script( 'woocommerce_subscriptions_gifting' );
 	}
 


### PR DESCRIPTION
Modified the script enqueueing to move the .js file to the footer to reduce the render blocking effect of too many scripts being loaded in the head. Needed to add the version number and 'in_footer' true to the enqueueing to shift it down.  Is there a reason we need this script to load in the <head>?  I'm testing on an existing installation and it appears to work fine being shifted to the footer.