### PR TITLE
Fix errors which occur when saving gifted subscriptions with downloads

### DIFF
--- a/includes/class-wcsg-download-handler.php
+++ b/includes/class-wcsg-download-handler.php
@@ -183,6 +183,11 @@ class WCSG_Download_Handler {
 	public static function download_permissions_meta_box_save( $subscription_id ) {
 		global $wpdb;
 
+		// Post WC 3.0 WC_Meta_Box_Order_Downloads::save() no longer overrides the user ID associated with the download permissions so the contents of this function aren't necessary.
+		if ( ! wcsg_is_woocommerce_pre( '3.0' ) ) {
+			return;
+		}
+
 		if ( isset( $_POST['wcsg_download_permission_ids'] ) && isset( $_POST['woocommerce_meta_nonce'] ) && wp_verify_nonce( $_POST['woocommerce_meta_nonce'], 'woocommerce_save_data' ) ) {
 
 			remove_action( 'woocommerce_process_shop_order_meta', 'WC_Meta_Box_Order_Downloads::save', 30 );


### PR DESCRIPTION
Post WC 3.0 it's no longer necessary to override the behaviour of `WC_Meta_Box_Order_Downloads::save()`. 

As the docblock comment of `download_permissions_meta_box_save()` suggests:

```php
/**
* We need to unhook WC_Meta_Box_Order_Downloads::save() to prevent the WC save function from being called because
* it does not differentiate between duplicate permissions for the same product on the same order even when the
* permissions are for different users (and with different permission IDs). This means it would modify all
* permissions on that order for that product and set them all to be for the same user, instead of keeping
* them for the different users.
*/
```

Ever since `3.0`, the `WC_Meta_Box_Order_Downloads::save()` function has been simplified massively and no longer overrides the user ID associated with the download permissions. Therefore the `download_permissions_meta_box_save()` function is no longer needs to run.

To replicate on `master`: 

1. Purchase a subscription product with downloadable files for a recipient
2. Go to the newly created subscription's edit subscription admin screen
3. Save the subscription - no changes are necessary
4. You should receive the following errors: 

 ```
Undefined index: download_id in /includes/class-wcsg-download-handler.php on line 192
Undefined index: product_id in /includes/class-wcsg-download-handler.php on line 193
Invalid argument supplied for foreach() in /includes/class-wcsg-download-handler.php on line 199
Undefined index: downloads_remaining in /includes/class-wc-order.php on line 1378
Undefined index: access_expires in /includes/class-wc-order.php on line 1379
```