### PR TITLE
Include downloads remaining & access expiration args in downloadable files filtered by Gifting

### DIFF
--- a/includes/class-wcsg-download-handler.php
+++ b/includes/class-wcsg-download-handler.php
@@ -400,8 +400,12 @@ class WCSG_Download_Handler {
 				if ( wcsg_is_woocommerce_pre( '3.0' ) ) {
 					$files[ $download->download_id ] = $product->get_file( $download->download_id );
 				} else {
-					$file                            = $product->get_file( $download->download_id );
-					$files[ $download->download_id ] = $file->get_data();
+					$customer_download = new WC_Customer_Download( $download );
+					$file              = $product->get_file( $download->download_id );
+
+					$files[ $download->download_id ]                        = $file->get_data();
+					$files[ $download->download_id ]['downloads_remaining'] = $customer_download->get_downloads_remaining();
+					$files[ $download->download_id ]['access_expires']      = $customer_download->get_access_expires();
 				}
 
 				$files[ $download->download_id ]['download_url'] = add_query_arg(


### PR DESCRIPTION
Similar to #257 this PR fixes errors when gifting filters the download permissions. 

To replicate on `master`: 

1. Turn on purchaser download permissions from **WooCommerce >
 Settings > Subscriptions** (https://cloudup.com/cNK1m4ZTbc3)
1. Purchase any subscription product with downloadable files for a recipient
2. When the order-received page is loaded, you should get the following errors:

```
Undefined index: downloads_remaining in /wp-content/plugins/woocommerce/includes/class-wc-order.php on line 1378
PHP Notice:  Undefined index: access_expires in /wp-content/plugins/woocommerce/includes/class-wc-order.php on line 1379
```

The error is caused by Gifting filtering the download links so that we display the downloads belonging to the current user, however, we weren't including all the args. 

This PR adds the `['downloads_remaining]` & `['access_expires']` args similar to how WC do it [here](https://github.com/woocommerce/woocommerce/blob/3.3.3/includes/class-wc-order-item-product.php#L385-L386).