### PR TITLE
Use user ID variable instead of undeclared variable

### DIFF
--- a/woocommerce-subscriptions-gifting.php
+++ b/woocommerce-subscriptions-gifting.php
@@ -537,7 +537,7 @@ class WCS_Gifting {
 
 		} else {
 
-			$subscription->recipient_user = $recipient_user_id;
+			$subscription->recipient_user = $user_id;
 
 			if ( 'save' === $save ) {
 				if ( ! empty( $meta_id ) ) {


### PR DESCRIPTION
Fixes the following error when setting recipient users on versions of WC prior to 3.0

```
PHP Notice:  Undefined variable: recipient_user_id in /wp-content/plugins/woocommerce-subscriptions-gifting/woocommerce-subscriptions-gifting.php on line 540
```

To replicate: 

1. on WC `2.6.14` attempt to purchase any subscription product for a recipient user
2. the error included above should occur immediately after submitting the checkout form
