### PR TITLE
Attach dependant hooks on init now that classes are inited after WC load

### DIFF
--- a/includes/class-wcsg-recipient-management.php
+++ b/includes/class-wcsg-recipient-management.php
@@ -39,16 +39,6 @@ class WCSG_Recipient_Management {
 
 		add_action( 'woocommerce_subscription_status_updated', __CLASS__ . '::maybe_update_recipient_role', 10, 2 );
 
-		add_action( 'woocommerce_loaded', __CLASS__ . '::attach_dependant_hooks', 10 );
-	}
-
-	/**
-	 * Attach WooCommerce version dependent hooks
-	 *
-	 * @since 1.0.1
-	 */
-	public static function attach_dependant_hooks() {
-
 		if ( wcsg_is_woocommerce_pre( '3.0' ) ) {
 			add_action( 'woocommerce_add_order_item_meta', __CLASS__ . '::maybe_add_recipient_order_item_meta', 10, 2 );
 		} else {
@@ -523,6 +513,16 @@ class WCSG_Recipient_Management {
 		if ( $recipient_user_id ) {
 			$item->add_meta_data( 'wcsg_recipient', 'wcsg_recipient_id_' . $recipient_user_id );
 		}
+	}
+
+	/**
+	 * Attach WooCommerce version dependent hooks
+	 *
+	 * @since 1.0.1
+	 * @deprecated 2.0.0
+	 */
+	public static function attach_dependant_hooks() {
+		_deprecated_function( __METHOD__, '2.0.0', __CLASS__ . '::init()' );
 	}
 }
 WCSG_Recipient_Management::init();

--- a/woocommerce-subscriptions-gifting.php
+++ b/woocommerce-subscriptions-gifting.php
@@ -617,6 +617,7 @@ function wcsg_load() {
 		return;
 	}
 
+	require_once( 'includes/wcsg-compatibility-functions.php' );
 	require_once( 'includes/class-wcsg-product.php' );
 	require_once( 'includes/class-wcsg-cart.php' );
 	require_once( 'includes/class-wcsg-checkout.php' );
@@ -626,7 +627,6 @@ function wcsg_load() {
 	require_once( 'includes/class-wcsg-download-handler.php' );
 	require_once( 'includes/class-wcsg-admin.php' );
 	require_once( 'includes/class-wcsg-recipient-addresses.php' );
-	require_once( 'includes/wcsg-compatibility-functions.php' );
 
 	WCS_Gifting::init();
 }


### PR DESCRIPTION
After #249 WCSG classes are now included and initialised after WC loaded (`woocommerce_loaded`). This means functions like `WCSG_Recipient_Management::attach_dependant_hooks()` wont ever run because by the time the class is included the hook its attached to, `woocommerce_loaded`, has already come and gone. 

To fix that now just attach the dependant hooks inside the init. 

To ensure the `wcsg_is_woocommerce_pre()` function is available, I also had to change when that function's containing file is included to the top of the list. 

Without this change, new recipient users aren't being created 😱 