### PR TITLE
Deprecate unused WCSG_Query functions and update their function signature

### DIFF
--- a/includes/class-wcsg-query.php
+++ b/includes/class-wcsg-query.php
@@ -67,10 +67,27 @@ class WCSG_Query extends WCS_Query {
 
 	/* Function Overrides */
 
+	/**
+	* This function is attached to the 'woocommerce_account_menu_items' filter by the @see parent::__construct().
+	* In this context there is no menu items to add so this function is simply overriding the parent instance to avoid it from being called twice.
+	*
+	 * @param array $menu_items The My Account menu items.
+	 * @deprecated 2.0.0 Because parent::__construct() is no longer called, this function is no longer attached to any filters, no longer called and so no longer needs to be overridden.
+	 */
 	public function add_menu_items( $menu_items ) {
+		_deprecated_function( __METHOD__, '2.0' );
 		return $menu_items;
 	}
 
-	public function endpoint_content() {}
+	/**
+	 * This function is attached to the 'woocommerce_account_subscriptions_endpoint' action hook by the @see parent::__construct().
+	 * In this context there is no subscriptions endpoint content so this function is simply overriding the parent instance to avoid it from being called twice.
+	 *
+	 * @param int $current_page
+	 * @deprecated 2.0.0 Because parent::__construct() is no longer called, this function is no longer attached to any hooks, no longer called and so no longer needs to be overridden.
+	 */
+	public function endpoint_content( $current_page = 1 ) {
+		_deprecated_function( __METHOD__, '2.0' );
+	}
 }
 new WCSG_Query();


### PR DESCRIPTION
In Subscriptions recently the `WCS_Query::endpoint_content()` function signature was updated to include a new argument, the subscription page number. This was added as part of https://github.com/Prospress/woocommerce-subscriptions/pull/2537.

`WCSG_Query` was overriding that function and so the following warnings were being thrown: 

```
PHP Warning:  Declaration of WCSG_Query::endpoint_content() should be compatible with WCS_Query::endpoint_content($current_page = 1) in /app/public/wp-content/plugins/woocommerce-subscriptions-gifting/includes/class-wcsg-query.php on line 75
```

This PR updates that function's signature to include that new arg but also deprecates that function and `WCSG_Query::add_menu_items()` because they are no longer necessary. 

As the new block comments suggest, I originally overrode those two functions because `WCSG_Query` use to call the parent constructor which would attach these [callbacks](https://github.com/Prospress/woocommerce-subscriptions/blob/2.2.18/includes/class-wcs-query.php#L17-L26). To avoid two instances of `WCS_Query::endpoint_content()` and `WCS_Query::add_menu_items()` being attached to the same call back, I overrode those functions in `WCSG_Query`. 

The parent constructor is no longer called so this is no longer necessary.  