### PR TITLE
Email template refactoring and tweaks

### DIFF
--- a/includes/class-wcsg-email.php
+++ b/includes/class-wcsg-email.php
@@ -38,6 +38,8 @@ class WCSG_Email {
 		add_filter( 'woocommerce_email_classes', __CLASS__ . '::add_new_recipient_customer_email', 11, 1 );
 		add_action( 'woocommerce_init', __CLASS__ . '::hook_email' );
 		add_action( 'wcs_gifting_email_order_details', array( __CLASS__, 'order_details' ), 10, 4 );
+		add_action( 'woocommerce_subscriptions_gifting_recipient_email_details', array( __CLASS__, 'get_related_subscriptions_table' ), 10, 3 );
+		add_action( 'woocommerce_subscriptions_gifting_recipient_email_details', array( __CLASS__, 'get_address_table' ), 11, 3 );
 	}
 
 	/**
@@ -327,6 +329,48 @@ class WCSG_Email {
 				'email'                  => $email,
 				'order_items_table_args' => $order_items_table_args,
 			),
+			'',
+			plugin_dir_path( WCS_Gifting::$plugin_file ) . 'templates/'
+		);
+	}
+
+	/**
+	 * Get the related subscription details table for emails sent to recipients.
+	 *
+	 * @param WC_Order $order     The order object the email be sent relates to.
+	 * @param bool $sent_to_admin Whether the email is sent to admin users.
+	 * @param bool $plain_text    Whether the email template is plain text or HTML.
+	 * @since 2.0.0
+	 */
+	public static function get_related_subscriptions_table( $order, $sent_to_admin, $plain_text ) {
+		$subscriptions = wcs_get_subscriptions_for_renewal_order( $order );
+		$template      = ( $plain_text ) ? 'emails/plain/recipient-email-subscriptions-table.php' : 'emails/recipient-email-subscriptions-table.php';
+
+		// Only display the table if there are related subscriptions.
+		if ( ! empty( $subscriptions ) ) {
+			wc_get_template(
+				$template,
+				array( 'subscriptions' => $subscriptions ),
+				'',
+				plugin_dir_path( WCS_Gifting::$plugin_file ) . 'templates/'
+			);
+		}
+	}
+
+	/**
+	 * Get the order's address details table for emails sent to recipients.
+	 *
+	 * @param WC_Order $order     The order object the email be sent relates to.
+	 * @param bool $sent_to_admin Whether the email is sent to admin users.
+	 * @param bool $plain_text    Whether the email template is plain text.
+	 * @since 2.0.0
+	 */
+	public static function get_address_table( $order, $sent_to_admin, $plain_text ) {
+		$template = ( $plain_text ) ? 'emails/plain/recipient-email-address-table.php' : 'emails/recipient-email-address-table.php';
+
+		wc_get_template(
+			$template,
+			array( 'order' => $order ),
 			'',
 			plugin_dir_path( WCS_Gifting::$plugin_file ) . 'templates/'
 		);

--- a/includes/class-wcsg-email.php
+++ b/includes/class-wcsg-email.php
@@ -291,9 +291,28 @@ class WCSG_Email {
 	* @since 2.0.0
 	*/
 	public static function recipient_email_order_items_table( $order, $args ) {
+		$defaults = array(
+			'show_sku'      => false,
+			'show_image'    => false,
+			'image_size'    => array( 32, 32 ),
+			'plain_text'    => false,
+			'sent_to_admin' => false,
+		);
+
+		$args     = wp_parse_args( $args, $defaults );
 		$template = $args['plain_text'] ? 'emails/plain/recipient-email-order-items.php' : 'emails/recipient-email-order-items.php';
 
-		wc_get_template( $template, $args, '', plugin_dir_path( WCS_Gifting::$plugin_file ) . 'templates/' );
+		wc_get_template( $template, array(
+			'order'               => $order,
+			'items'               => $order->get_items(),
+			'show_download_links' => $order->is_download_permitted() && ! $args['sent_to_admin'],
+			'show_sku'            => $args['show_sku'],
+			'show_purchase_note'  => $order->is_paid() && ! $args['sent_to_admin'],
+			'show_image'          => $args['show_image'],
+			'image_size'          => $args['image_size'],
+			'plain_text'          => $args['plain_text'],
+			'sent_to_admin'       => $args['sent_to_admin'],
+		), '', plugin_dir_path( WCS_Gifting::$plugin_file ) . 'templates/' );
 	}
 
 	/**
@@ -306,28 +325,15 @@ class WCSG_Email {
 	 * @since 2.0.0
 	 */
 	public static function order_details( $order, $sent_to_admin = false, $plain_text = false, $email = '' ) {
-
-		$order_items_table_args = array(
-			'order'               => $order,
-			'items'               => $order->get_items(),
-			'show_download_links' => ( $sent_to_admin ) ? false : $order->is_download_permitted(),
-			'show_sku'            => $sent_to_admin,
-			'show_purchase_note'  => false,
-			'show_image'          => '',
-			'image_size'          => '',
-			'plain_text'          => $plain_text,
-		);
-
 		$template_path = ( $plain_text ) ? 'emails/plain/recipient-email-order-details.php' : 'emails/recipient-email-order-details.php';
 
 		wc_get_template(
 			$template_path,
 			array(
-				'order'                  => $order,
-				'sent_to_admin'          => $sent_to_admin,
-				'plain_text'             => $plain_text,
-				'email'                  => $email,
-				'order_items_table_args' => $order_items_table_args,
+				'order'         => $order,
+				'sent_to_admin' => $sent_to_admin,
+				'plain_text'    => $plain_text,
+				'email'         => $email,
 			),
 			'',
 			plugin_dir_path( WCS_Gifting::$plugin_file ) . 'templates/'

--- a/includes/class-wcsg-email.php
+++ b/includes/class-wcsg-email.php
@@ -35,11 +35,8 @@ class WCSG_Email {
 	 * Setup hooks & filters, when the class is initialised.
 	 */
 	public static function init() {
-
 		add_filter( 'woocommerce_email_classes', __CLASS__ . '::add_new_recipient_customer_email', 11, 1 );
-
 		add_action( 'woocommerce_init', __CLASS__ . '::hook_email' );
-
 		add_action( 'wcs_gifting_email_order_details', array( __CLASS__, 'order_details' ), 10, 4 );
 	}
 

--- a/includes/class-wcsg-email.php
+++ b/includes/class-wcsg-email.php
@@ -320,7 +320,6 @@ class WCSG_Email {
 		);
 
 		$template_path = ( $plain_text ) ? 'emails/plain/recipient-email-order-details.php' : 'emails/recipient-email-order-details.php';
-		$order_type    = ( wcs_is_subscription( $order ) ) ? 'subscription' : 'order';
 
 		wc_get_template(
 			$template_path,

--- a/includes/class-wcsg-email.php
+++ b/includes/class-wcsg-email.php
@@ -327,6 +327,12 @@ class WCSG_Email {
 	public static function order_details( $order, $sent_to_admin = false, $plain_text = false, $email = '' ) {
 		$template_path = ( $plain_text ) ? 'emails/plain/recipient-email-order-details.php' : 'emails/recipient-email-order-details.php';
 
+		if ( wcs_is_subscription( $order ) ) {
+			$title = sprintf( _x( 'Subscription #%s', 'Used in email heading before line items table, placeholder is subscription ID', 'woocommerce-subscriptions-gifting' ), $order->get_order_number() );
+		} else {
+			$title = sprintf( _x( 'Order #%s', 'Used in email heading before line items table, placeholder is order ID', 'woocommerce-subscriptions-gifting' ), $order->get_order_number() );
+		}
+
 		wc_get_template(
 			$template_path,
 			array(
@@ -334,6 +340,7 @@ class WCSG_Email {
 				'sent_to_admin' => $sent_to_admin,
 				'plain_text'    => $plain_text,
 				'email'         => $email,
+				'title'         => $title,
 			),
 			'',
 			plugin_dir_path( WCS_Gifting::$plugin_file ) . 'templates/'

--- a/templates/emails/plain/recipient-completed-renewal-order.php
+++ b/templates/emails/plain/recipient-completed-renewal-order.php
@@ -16,32 +16,11 @@ if ( is_callable( array( 'WC_Subscriptions_Email', 'order_download_details' ) ) 
 
 do_action( 'wcs_gifting_email_order_details', $order, $sent_to_admin, $plain_text, $email );
 
-$subscriptions = wcs_get_subscriptions_for_renewal_order( $order );
-
 echo "\n";
 
-foreach ( $subscriptions as $subscription ) {
-
-	echo sprintf( __( 'Subscription #%s', 'woocommerce-subscriptions-gifting' ), $subscription->get_order_number() ) . "\n";
-
-	echo sprintf( __( 'Start Date: %s', 'woocommerce-subscriptions-gifting' ), date_i18n( wc_date_format(), $subscription->get_time( 'date_created', 'site' ) ) ) . "\n";
-
-	echo sprintf( __( 'End Date: %s', 'woocommerce-subscriptions-gifting' ), ( 0 < $subscription->get_time( 'end' ) ) ? date_i18n( wc_date_format(), $subscription->get_time( 'end', 'site' ) ) : _x( 'When Cancelled', 'Used as end date for an indefinite subscription', 'woocommerce-subscriptions-gifting' ) ) . "\n";
-
-	$subscription_details = array(
-		'recurring_amount'            => '',
-		'subscription_period'         => $subscription->get_billing_period(),
-		'subscription_interval'       => $subscription->get_billing_interval(),
-		'initial_amount'              => '',
-		'use_per_slash'               => false,
-	);
-	$subscription_details = apply_filters( 'woocommerce_subscription_price_string_details', $subscription_details, $subscription );
-	echo sprintf( __( 'Period: %s', 'woocommerce-subscriptions-gifting' ), wp_kses_post( wcs_price_string( $subscription_details ) ) ) . "\n";
-
-	echo "----------\n\n";
-}
-
 do_action( 'woocommerce_email_order_meta', $order, $sent_to_admin, $plain_text, $email );
+
+do_action( 'woocommerce_subscriptions_gifting_recipient_email_details', $order, $sent_to_admin, $plain_text, $email );
 
 echo "\n=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
 

--- a/templates/emails/plain/recipient-email-address-table.php
+++ b/templates/emails/plain/recipient-email-address-table.php
@@ -1,0 +1,9 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly
+}
+
+if ( ! wc_ship_to_billing_address_only() && $order->needs_shipping_address() && ( $shipping = $order->get_formatted_shipping_address() ) ) {
+	echo "\n" . strtoupper( __( 'Shipping address', 'woocommerce-subscriptions-gifting' ) ) . "\n\n";
+	echo preg_replace( '#<br\s*/?>#i', "\n", $shipping ) . "\n";
+}

--- a/templates/emails/plain/recipient-email-order-details.php
+++ b/templates/emails/plain/recipient-email-order-details.php
@@ -7,10 +7,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly
 }
 
-echo sprintf( __( 'Order number: %s', 'woocommerce-subscriptions' ), $order->get_order_number() ) . "\n";
-echo sprintf( __( 'Order date: %s', 'woocommerce-subscriptions' ), wcs_format_datetime( wcs_get_objects_property( $order, 'date_created' ) ) ) . "\n";
-
-echo "\n";
+echo esc_html( $title ) . "\n\n";
 
 echo wp_kses_post( WCSG_Email::recipient_email_order_items_table( $order, array(
 	'show_sku'            => $sent_to_admin,

--- a/templates/emails/plain/recipient-email-order-details.php
+++ b/templates/emails/plain/recipient-email-order-details.php
@@ -14,4 +14,4 @@ echo "\n";
 
 echo wp_kses_post( WCSG_Email::recipient_email_order_items_table( $order, $order_items_table_args ) );
 
-echo "----------\n\n";
+echo "----------\n";

--- a/templates/emails/plain/recipient-email-order-details.php
+++ b/templates/emails/plain/recipient-email-order-details.php
@@ -12,6 +12,12 @@ echo sprintf( __( 'Order date: %s', 'woocommerce-subscriptions' ), wcs_format_da
 
 echo "\n";
 
-echo wp_kses_post( WCSG_Email::recipient_email_order_items_table( $order, $order_items_table_args ) );
+echo wp_kses_post( WCSG_Email::recipient_email_order_items_table( $order, array(
+	'show_sku'            => $sent_to_admin,
+	'show_image'          => '',
+	'image_size'          => '',
+	'plain_text'          => $plain_text,
+	'sent_to_admin'       => $sent_to_admin,
+) ) );
 
 echo "----------\n";

--- a/templates/emails/plain/recipient-email-subscriptions-table.php
+++ b/templates/emails/plain/recipient-email-subscriptions-table.php
@@ -1,0 +1,24 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly
+}
+
+foreach ( $subscriptions as $subscription ) {
+	echo sprintf( __( 'Subscription #%s', 'woocommerce-subscriptions-gifting' ), $subscription->get_order_number() ) . "\n";
+
+	echo sprintf( __( 'Start Date: %s', 'woocommerce-subscriptions-gifting' ), date_i18n( wc_date_format(), $subscription->get_time( 'date_created', 'site' ) ) ) . "\n";
+
+	echo sprintf( __( 'End Date: %s', 'woocommerce-subscriptions-gifting' ), ( 0 < $subscription->get_time( 'end' ) ) ? date_i18n( wc_date_format(), $subscription->get_time( 'end', 'site' ) ) : _x( 'When Cancelled', 'Used as end date for an indefinite subscription', 'woocommerce-subscriptions-gifting' ) ) . "\n";
+
+	$subscription_details = array(
+		'recurring_amount'            => '',
+		'subscription_period'         => $subscription->get_billing_period(),
+		'subscription_interval'       => $subscription->get_billing_interval(),
+		'initial_amount'              => '',
+		'use_per_slash'               => false,
+	);
+	$subscription_details = apply_filters( 'woocommerce_subscription_price_string_details', $subscription_details, $subscription );
+	echo sprintf( __( 'Period: %s', 'woocommerce-subscriptions-gifting' ), wp_kses_post( wcs_price_string( $subscription_details ) ) ) . "\n";
+
+	echo "----------\n";
+}

--- a/templates/emails/plain/recipient-new-initial-order.php
+++ b/templates/emails/plain/recipient-new-initial-order.php
@@ -25,27 +25,11 @@ if ( 'true' == $new_recipient ) {
 foreach ( $subscriptions as $subscription_id ) {
 	$subscription = wcs_get_subscription( $subscription_id );
 
-	echo sprintf( __( 'Subscription #%s', 'woocommerce-subscriptions-gifting' ), $subscription->get_order_number() ) . "\n";
-
-	echo sprintf( __( 'Start Date: %s', 'woocommerce-subscriptions-gifting' ), date_i18n( wc_date_format(), $subscription->get_time( 'date_created', 'site' ) ) ) . "\n";
-
-	echo sprintf( __( 'End Date: %s', 'woocommerce-subscriptions-gifting' ), ( 0 < $subscription->get_time( 'end' ) ) ? date_i18n( wc_date_format(), $subscription->get_time( 'end', 'site' ) ) : _x( 'When Cancelled', 'Used as end date for an indefinite subscription', 'woocommerce-subscriptions-gifting' ) ) . "\n";
-
-	$subscription_details = array(
-		'recurring_amount'            => '',
-		'subscription_period'         => $subscription->get_billing_period(),
-		'subscription_interval'       => $subscription->get_billing_interval(),
-		'initial_amount'              => '',
-		'use_per_slash'               => false,
-	);
-	$subscription_details = apply_filters( 'woocommerce_subscription_price_string_details', $subscription_details, $subscription );
-	echo sprintf( __( 'Period: %s', 'woocommerce-subscriptions-gifting' ), wp_kses_post( wcs_price_string( $subscription_details ) ) ) . "\n";
+	do_action( 'wcs_gifting_email_order_details', $subscription, $sent_to_admin, $plain_text, $email );
 
 	if ( is_callable( array( 'WC_Subscriptions_Email', 'order_download_details' ) ) ) {
 		WC_Subscriptions_Email::order_download_details( $subscription, $sent_to_admin, $plain_text, $email );
 	}
-
-	echo "----------\n\n";
 }
 
 echo apply_filters( 'woocommerce_email_footer_text', get_option( 'woocommerce_email_footer_text' ) );

--- a/templates/emails/plain/recipient-processing-renewal-order.php
+++ b/templates/emails/plain/recipient-processing-renewal-order.php
@@ -15,32 +15,11 @@ if ( is_callable( array( 'WC_Subscriptions_Email', 'order_download_details' ) ) 
 
 do_action( 'wcs_gifting_email_order_details', $order, $sent_to_admin, $plain_text, $email );
 
-$subscriptions = wcs_get_subscriptions_for_renewal_order( $order );
-
 echo "\n";
 
-foreach ( $subscriptions as $subscription ) {
-
-	echo sprintf( __( 'Subscription #%s', 'woocommerce-subscriptions-gifting' ), $subscription->get_order_number() ) . "\n";
-
-	echo sprintf( __( 'Start Date: %s', 'woocommerce-subscriptions-gifting' ), date_i18n( wc_date_format(), $subscription->get_time( 'date_created', 'site' ) ) ) . "\n";
-
-	echo sprintf( __( 'End Date: %s', 'woocommerce-subscriptions-gifting' ), ( 0 < $subscription->get_time( 'end' ) ) ? date_i18n( wc_date_format(), $subscription->get_time( 'end', 'site' ) ) : _x( 'When Cancelled', 'Used as end date for an indefinite subscription', 'woocommerce-subscriptions-gifting' ) ) . "\n";
-
-	$subscription_details = array(
-		'recurring_amount'            => '',
-		'subscription_period'         => $subscription->get_billing_period(),
-		'subscription_interval'       => $subscription->get_billing_interval(),
-		'initial_amount'              => '',
-		'use_per_slash'               => false,
-	);
-	$subscription_details = apply_filters( 'woocommerce_subscription_price_string_details', $subscription_details, $subscription );
-	echo sprintf( __( 'Period: %s', 'woocommerce-subscriptions-gifting' ), wp_kses_post( wcs_price_string( $subscription_details ) ) ) . "\n";
-
-	echo "----------\n\n";
-}
-
 do_action( 'woocommerce_email_order_meta', $order, $sent_to_admin, $plain_text, $email );
+
+do_action( 'woocommerce_subscriptions_gifting_recipient_email_details', $order, $sent_to_admin, $plain_text, $email );
 
 echo "\n=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
 

--- a/templates/emails/recipient-completed-renewal-order.php
+++ b/templates/emails/recipient-completed-renewal-order.php
@@ -1,5 +1,4 @@
 <?php
-
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly
 }
@@ -7,8 +6,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 <?php do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 
-<p>
-	<?php
+<p><?php
 	// translators: placeholder is the name of the site
 	printf( esc_html__( 'Hi there. Your subscription renewal order with %s has been completed. Your order details are shown below for your reference:', 'woocommerce-subscriptions-gifting' ), esc_html( get_option( 'blogname' ) ) );
 	?>

--- a/templates/emails/recipient-completed-renewal-order.php
+++ b/templates/emails/recipient-completed-renewal-order.php
@@ -5,8 +5,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 ?>
 
-<?php $subscriptions = wcs_get_subscriptions_for_renewal_order( $order ); ?>
-
 <?php do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 
 <p>
@@ -26,51 +24,6 @@ if ( is_callable( array( 'WC_Subscriptions_Email', 'order_download_details' ) ) 
 
 <?php do_action( 'woocommerce_email_order_meta', $order, $sent_to_admin, $plain_text, $email ); ?>
 
-<?php if ( ! empty( $subscriptions ) ) : ?>
-<h2><?php esc_html_e( 'Subscription Information:', 'woocommerce-subscriptions-gifting' ); ?></h2>
-<table class="td" cellspacing="0" cellpadding="6" style="width: 100%; font-family: 'Helvetica Neue', Helvetica, Roboto, Arial, sans-serif;" border="1">
-	<thead>
-		<tr>
-			<th class="td" scope="col" style="text-align:left;"><?php esc_html_e( 'Subscription', 'woocommerce-subscriptions-gifting' ); ?></th>
-			<th class="td" scope="col" style="text-align:left;"><?php echo esc_html_x( 'Start Date', 'table heading',  'woocommerce-subscriptions-gifting' ); ?></th>
-			<th class="td" scope="col" style="text-align:left;"><?php echo esc_html_x( 'End Date', 'table heading',  'woocommerce-subscriptions-gifting' ); ?></th>
-			<th class="td" scope="col" style="text-align:left;"><?php echo esc_html_x( 'Period',  'table heading', 'woocommerce-subscriptions-gifting' ); ?></th>
-		</tr>
-	</thead>
-	<tbody>
-	<?php foreach ( $subscriptions as $subscription ) : ?>
-		<tr>
-			<td class="td" scope="row" style="text-align:left;"><a href="<?php echo esc_url( $subscription->get_view_order_url() ); ?>"><?php echo sprintf( esc_html_x( '#%s', 'subscription number in email table. (eg: #106)', 'woocommerce-subscriptions-gifting' ), esc_html( $subscription->get_order_number() ) ); ?></a></td>
-			<td class="td" scope="row" style="text-align:left;"><?php echo esc_html( date_i18n( wc_date_format(), $subscription->get_time( 'date_created', 'site' ) ) ); ?></td>
-			<td class="td" scope="row" style="text-align:left;"><?php echo esc_html( ( 0 < $subscription->get_time( 'end' ) ) ? date_i18n( wc_date_format(), $subscription->get_time( 'end', 'site' ) ) : _x( 'When Cancelled', 'Used as end date for an indefinite subscription', 'woocommerce-subscriptions-gifting' ) ); ?></td>
-			<td class="td" scope="row" style="text-align:left;">
-				<?php
-				$subscription_details = array(
-					'recurring_amount'            => '',
-					'subscription_period'         => $subscription->get_billing_period(),
-					'subscription_interval'       => $subscription->get_billing_interval(),
-					'initial_amount'              => '',
-					'use_per_slash'               => false,
-				);
-				$subscription_details = apply_filters( 'woocommerce_subscription_price_string_details', $subscription_details, $subscription );
-				echo wp_kses_post( wcs_price_string( $subscription_details ) );?>
-			</td>
-		</tr>
-	<?php endforeach; ?>
-</tbody>
-</table>
-<?php endif; ?>
-
-<table id="addresses" cellspacing="0" cellpadding="0" style="width: 100%; vertical-align: top; margin-bottom: 40px; padding:0;" border="0">
-	<tr>
-		<?php if ( ! wc_ship_to_billing_address_only() && $order->needs_shipping_address() && ( $shipping = $order->get_formatted_shipping_address() ) ) : ?>
-			<td style="font-family: 'Helvetica Neue', Helvetica, Roboto, Arial, sans-serif; padding:0;" valign="top" width="50%">
-				<h2><?php echo esc_html__( 'Shipping address', 'woocommerce-subscriptions-gifting' ); ?></h2>
-
-				<address class="address"><?php echo wp_kses_post( $shipping ); ?></address>
-			</td>
-		<?php endif; ?>
-	</tr>
-</table>
+<?php do_action( 'woocommerce_subscriptions_gifting_recipient_email_details', $order, $sent_to_admin, $plain_text, $email ); ?>
 
 <?php do_action( 'woocommerce_email_footer', $email ); ?>

--- a/templates/emails/recipient-email-address-table.php
+++ b/templates/emails/recipient-email-address-table.php
@@ -1,0 +1,16 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly
+}
+?>
+<table id="addresses" cellspacing="0" cellpadding="0" style="width: 100%; vertical-align: top; margin-bottom: 40px; padding:0;" border="0">
+	<tr>
+		<?php if ( ! wc_ship_to_billing_address_only() && $order->needs_shipping_address() && ( $shipping = $order->get_formatted_shipping_address() ) ) : ?>
+			<td style="font-family: 'Helvetica Neue', Helvetica, Roboto, Arial, sans-serif; padding:0;" valign="top" width="50%">
+				<h2><?php echo esc_html__( 'Shipping address', 'woocommerce-subscriptions-gifting' ); ?></h2>
+
+				<address class="address"><?php echo wp_kses_post( $shipping ); ?></address>
+			</td>
+		<?php endif; ?>
+	</tr>
+</table>

--- a/templates/emails/recipient-email-order-details.php
+++ b/templates/emails/recipient-email-order-details.php
@@ -13,6 +13,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 		</tr>
 	</thead>
 	<tbody>
-		<?php echo wp_kses_post( WCSG_Email::recipient_email_order_items_table( $order, $order_items_table_args ) ); ?>
+		<?php echo wp_kses_post( WCSG_Email::recipient_email_order_items_table( $order, array(
+			'show_sku'            => $sent_to_admin,
+			'show_image'          => '',
+			'image_size'          => '',
+			'plain_text'          => $plain_text,
+			'sent_to_admin'       => $sent_to_admin,
+		) ) ); ?>
 	</tbody>
 </table>

--- a/templates/emails/recipient-email-order-details.php
+++ b/templates/emails/recipient-email-order-details.php
@@ -4,18 +4,15 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly
 }
 ?>
-
-<table cellspacing="0" cellpadding="6" style="width: 100%; font-family: 'Helvetica Neue', Helvetica, Roboto, Arial, sans-serif;">
+<h2><?php printf( esc_html__( 'Order #%s', 'woocommerce-subscriptions-gifting' ), esc_attr( $order->get_order_number() ) ) ?></h2>
+<table cellspacing="0" cellpadding="6" style="margin: 0 0 18px; width: 100%; font-family: 'Helvetica Neue', Helvetica, Roboto, Arial, sans-serif;">
 	<thead>
-		<tr>
-			<td style="padding: -6" colspan="3"><h2><?php printf( esc_html__( 'Order #%s', 'woocommerce-subscriptions-gifting' ), esc_attr( $order->get_order_number() ) ) ?></h2></td>
-		</tr>
-	</thead>
 		<tr>
 			<th class="td" scope="col" style="text-align:left;"><?php esc_html_e( 'Product', 'woocommerce-subscriptions-gifting' ); ?></th>
 			<th class="td" scope="col" style="text-align:left;"><?php esc_html_e( 'Quantity', 'woocommerce-subscriptions-gifting' ); ?></th>
 		</tr>
+	</thead>
 	<tbody>
 		<?php echo wp_kses_post( WCSG_Email::recipient_email_order_items_table( $order, $order_items_table_args ) ); ?>
 	</tbody>
-<?php echo '</table>'; ?>
+</table>

--- a/templates/emails/recipient-email-order-details.php
+++ b/templates/emails/recipient-email-order-details.php
@@ -4,7 +4,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly
 }
 ?>
-<h2><?php printf( esc_html__( 'Order #%s', 'woocommerce-subscriptions-gifting' ), esc_attr( $order->get_order_number() ) ) ?></h2>
+<h2><?php echo esc_html( $title ) ?></h2>
 <table cellspacing="0" cellpadding="6" style="margin: 0 0 18px; width: 100%; font-family: 'Helvetica Neue', Helvetica, Roboto, Arial, sans-serif;">
 	<thead>
 		<tr>

--- a/templates/emails/recipient-email-subscriptions-table.php
+++ b/templates/emails/recipient-email-subscriptions-table.php
@@ -1,0 +1,37 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly
+}
+?>
+<h2><?php esc_html_e( 'Subscription Information', 'woocommerce-subscriptions-gifting' ); ?></h2>
+<table cellspacing="0" cellpadding="6" style="margin: 0 0 18px; width: 100%; font-family: 'Helvetica Neue', Helvetica, Roboto, Arial, sans-serif;">
+	<thead>
+		<tr>
+			<th class="td" scope="col" style="text-align:left;"><?php esc_html_e( 'Subscription', 'woocommerce-subscriptions-gifting' ); ?></th>
+			<th class="td" scope="col" style="text-align:left;"><?php echo esc_html_x( 'Start Date', 'table heading',  'woocommerce-subscriptions-gifting' ); ?></th>
+			<th class="td" scope="col" style="text-align:left;"><?php echo esc_html_x( 'End Date', 'table heading',  'woocommerce-subscriptions-gifting' ); ?></th>
+			<th class="td" scope="col" style="text-align:left;"><?php echo esc_html_x( 'Period',  'table heading', 'woocommerce-subscriptions-gifting' ); ?></th>
+		</tr>
+	</thead>
+	<tbody>
+	<?php foreach ( $subscriptions as $subscription ) : ?>
+		<tr>
+			<td class="td" scope="row" style="text-align:left;"><a href="<?php echo esc_url( $subscription->get_view_order_url() ); ?>"><?php echo sprintf( esc_html_x( '#%s', 'subscription number in email table. (eg: #106)', 'woocommerce-subscriptions-gifting' ), esc_html( $subscription->get_order_number() ) ); ?></a></td>
+			<td class="td" scope="row" style="text-align:left;"><?php echo esc_html( date_i18n( wc_date_format(), $subscription->get_time( 'date_created', 'site' ) ) ); ?></td>
+			<td class="td" scope="row" style="text-align:left;"><?php echo esc_html( ( 0 < $subscription->get_time( 'end' ) ) ? date_i18n( wc_date_format(), $subscription->get_time( 'end', 'site' ) ) : _x( 'When Cancelled', 'Used as end date for an indefinite subscription', 'woocommerce-subscriptions-gifting' ) ); ?></td>
+			<td class="td" scope="row" style="text-align:left;">
+				<?php
+				$subscription_details = array(
+					'recurring_amount'            => '',
+					'subscription_period'         => $subscription->get_billing_period(),
+					'subscription_interval'       => $subscription->get_billing_interval(),
+					'initial_amount'              => '',
+					'use_per_slash'               => false,
+				);
+				$subscription_details = apply_filters( 'woocommerce_subscription_price_string_details', $subscription_details, $subscription );
+				echo wp_kses_post( wcs_price_string( $subscription_details ) );?>
+			</td>
+		</tr>
+	<?php endforeach; ?>
+	</tbody>
+</table>

--- a/templates/emails/recipient-new-initial-order.php
+++ b/templates/emails/recipient-new-initial-order.php
@@ -8,7 +8,6 @@
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly
 }
-
 ?>
 
 <?php do_action( 'woocommerce_email_header', $email_heading, $email ); ?>

--- a/templates/emails/recipient-new-initial-order.php
+++ b/templates/emails/recipient-new-initial-order.php
@@ -32,51 +32,16 @@ if ( 'true' == $new_recipient ) : ?>
 	'</a>'
 ); ?></p>
 
-<?php endif; ?>
+<?php endif;
 
-<?php if ( ! empty( $subscriptions ) ) : ?>
-<h2><?php esc_html_e( 'Subscription Information:', 'woocommerce-subscriptions-gifting' ); ?></h2>
-<table class="td" cellspacing="0" cellpadding="6" style="width: 100%; font-family: 'Helvetica Neue', Helvetica, Roboto, Arial, sans-serif;" border="1">
-	<thead>
-		<tr>
-			<th class="td" scope="col" style="text-align:left;"><?php esc_html_e( 'Subscription', 'woocommerce-subscriptions-gifting' ); ?></th>
-			<th class="td" scope="col" style="text-align:left;"><?php echo esc_html_x( 'Start Date', 'table heading',  'woocommerce-subscriptions-gifting' ); ?></th>
-			<th class="td" scope="col" style="text-align:left;"><?php echo esc_html_x( 'End Date', 'table heading',  'woocommerce-subscriptions-gifting' ); ?></th>
-			<th class="td" scope="col" style="text-align:left;"><?php echo esc_html_x( 'Period',  'table heading', 'woocommerce-subscriptions-gifting' ); ?></th>
-		</tr>
-	</thead>
-	<tbody>
-	<?php foreach ( $subscriptions as $subscription_id ) : ?>
-		<?php $subscription = wcs_get_subscription( $subscription_id ); ?>
-		<tr>
-			<td class="td" scope="row" style="text-align:left;"><a href="<?php echo esc_url( $subscription->get_view_order_url() ); ?>"><?php echo sprintf( esc_html_x( '#%s', 'subscription number in email table. (eg: #106)', 'woocommerce-subscriptions-gifting' ), esc_html( $subscription->get_order_number() ) ); ?></a></td>
-			<td class="td" scope="row" style="text-align:left;"><?php echo esc_html( date_i18n( wc_date_format(), $subscription->get_time( 'date_created', 'site' ) ) ); ?></td>
-			<td class="td" scope="row" style="text-align:left;"><?php echo esc_html( ( 0 < $subscription->get_time( 'end' ) ) ? date_i18n( wc_date_format(), $subscription->get_time( 'end', 'site' ) ) : _x( 'When Cancelled', 'Used as end date for an indefinite subscription', 'woocommerce-subscriptions-gifting' ) ); ?></td>
-			<td class="td" scope="row" style="text-align:left;">
-				<?php
-				$subscription_details = array(
-					'recurring_amount'            => '',
-					'subscription_period'         => $subscription->get_billing_period(),
-					'subscription_interval'       => $subscription->get_billing_interval(),
-					'initial_amount'              => '',
-					'use_per_slash'               => false,
-				);
-				$subscription_details = apply_filters( 'woocommerce_subscription_price_string_details', $subscription_details, $subscription );
-				echo wp_kses_post( wcs_price_string( $subscription_details ) );?>
-			</td>
-		</tr>
-	</tbody>
-</table>
-<table>
-	<tbody>
-		<?php if ( is_callable( array( 'WC_Subscriptions_Email', 'order_download_details' ) ) ) { ?>
-		<tr>
-			<td style="padding: 0" colspan="3"><p><?php WC_Subscriptions_Email::order_download_details( $subscription, $sent_to_admin, $plain_text, $email ); ?></p></td>
-		</tr>
-		<?php } ?>
-	</tbody>
-</table>
-	<?php endforeach; ?>
-<?php endif; ?>
+foreach ( $subscriptions as $subscription_id ) {
+	$subscription = wcs_get_subscription( $subscription_id );
 
-<?php do_action( 'woocommerce_email_footer', $email ); ?>
+	do_action( 'wcs_gifting_email_order_details', $subscription, $sent_to_admin, $plain_text, $email );
+
+	if ( is_callable( array( 'WC_Subscriptions_Email', 'order_download_details' ) ) ) {
+		WC_Subscriptions_Email::order_download_details( $subscription, $sent_to_admin, $plain_text, $email );
+	}
+}
+
+do_action( 'woocommerce_email_footer', $email );

--- a/templates/emails/recipient-processing-renewal-order.php
+++ b/templates/emails/recipient-processing-renewal-order.php
@@ -5,8 +5,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 ?>
 
-<?php $subscriptions = wcs_get_subscriptions_for_renewal_order( $order ); ?>
-
 <?php do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 
 <p><?php esc_html_e( 'Your subscription renewal order has been received and is now being processed. Your order details are shown below for your reference:', 'woocommerce-subscriptions-gifting' ); ?></p>
@@ -21,51 +19,6 @@ if ( is_callable( array( 'WC_Subscriptions_Email', 'order_download_details' ) ) 
 
 <?php do_action( 'woocommerce_email_order_meta', $order, $sent_to_admin, $plain_text, $email ); ?>
 
-<?php if ( ! empty( $subscriptions ) ) : ?>
-<h2><?php esc_html_e( 'Subscription Information:', 'woocommerce-subscriptions-gifting' ); ?></h2>
-<table class="td" cellspacing="0" cellpadding="6" style="width: 100%; font-family: 'Helvetica Neue', Helvetica, Roboto, Arial, sans-serif;" border="1">
-	<thead>
-		<tr>
-			<th class="td" scope="col" style="text-align:left;"><?php esc_html_e( 'Subscription', 'woocommerce-subscriptions-gifting' ); ?></th>
-			<th class="td" scope="col" style="text-align:left;"><?php echo esc_html_x( 'Start Date', 'table heading',  'woocommerce-subscriptions-gifting' ); ?></th>
-			<th class="td" scope="col" style="text-align:left;"><?php echo esc_html_x( 'End Date', 'table heading',  'woocommerce-subscriptions-gifting' ); ?></th>
-			<th class="td" scope="col" style="text-align:left;"><?php echo esc_html_x( 'Period',  'table heading', 'woocommerce-subscriptions-gifting' ); ?></th>
-		</tr>
-	</thead>
-	<tbody>
-	<?php foreach ( $subscriptions as $subscription ) : ?>
-		<tr>
-			<td class="td" scope="row" style="text-align:left;"><a href="<?php echo esc_url( $subscription->get_view_order_url() ); ?>"><?php echo sprintf( esc_html_x( '#%s', 'subscription number in email table. (eg: #106)', 'woocommerce-subscriptions-gifting' ), esc_html( $subscription->get_order_number() ) ); ?></a></td>
-			<td class="td" scope="row" style="text-align:left;"><?php echo esc_html( date_i18n( wc_date_format(), $subscription->get_time( 'date_created', 'site' ) ) ); ?></td>
-			<td class="td" scope="row" style="text-align:left;"><?php echo esc_html( ( 0 < $subscription->get_time( 'end' ) ) ? date_i18n( wc_date_format(), $subscription->get_time( 'end', 'site' ) ) : _x( 'When Cancelled', 'Used as end date for an indefinite subscription', 'woocommerce-subscriptions-gifting' ) ); ?></td>
-			<td class="td" scope="row" style="text-align:left;">
-				<?php
-				$subscription_details = array(
-					'recurring_amount'            => '',
-					'subscription_period'         => $subscription->get_billing_period(),
-					'subscription_interval'       => $subscription->get_billing_interval(),
-					'initial_amount'              => '',
-					'use_per_slash'               => false,
-				);
-				$subscription_details = apply_filters( 'woocommerce_subscription_price_string_details', $subscription_details, $subscription );
-				echo wp_kses_post( wcs_price_string( $subscription_details ) );?>
-			</td>
-		</tr>
-	<?php endforeach; ?>
-</tbody>
-</table>
-<?php endif; ?>
-
-<table id="addresses" cellspacing="0" cellpadding="0" style="width: 100%; vertical-align: top; margin-bottom: 40px; padding:0;" border="0">
-	<tr>
-		<?php if ( ! wc_ship_to_billing_address_only() && $order->needs_shipping_address() && ( $shipping = $order->get_formatted_shipping_address() ) ) : ?>
-			<td style="font-family: 'Helvetica Neue', Helvetica, Roboto, Arial, sans-serif; padding:0;" valign="top" width="50%">
-				<h2><?php echo esc_html__( 'Shipping address', 'woocommerce-subscriptions-gifting' ); ?></h2>
-
-				<address class="address"><?php echo wp_kses_post( $shipping ); ?></address>
-			</td>
-		<?php endif; ?>
-	</tr>
-</table>
+<?php do_action( 'woocommerce_subscriptions_gifting_recipient_email_details', $order, $sent_to_admin, $plain_text, $email ); ?>
 
 <?php do_action( 'woocommerce_email_footer', $email ); ?>


### PR DESCRIPTION
After merging #250, there were a still few changes that needed to be made to simplify the recipient email templates. 

The changes include

- Refactoring the recipient's subscriptions details table (https://cloudup.com/c6luozKV7vr) to its own template to avoid duplicates of the same table being in multiple emails. 
- Refactoring the recipient's address section (https://cloudup.com/cX-0U1M9IP5) moving that table to its own template.
- Fixing the initial order email template which had some styling issues when purchasing multiple subscriptions with downloads (https://cloudup.com/cbWkCimPw-w)
- I also changed the initial order email template back to include the line items rather than just the subscription details table. 
- Other whitespace and style changes.

There's a known issue with download links not being displayed correctly in the plain text initial order email. After a little bit of digging it appears to be caused by `$order->is_download_permitted()` returning false ([here](https://github.com/woocommerce/woocommerce/blob/3.3.3/includes/class-wc-emails.php#L368)) while sending the plain text email. 

I suspect this is caused by this [`did_action()`](https://github.com/Prospress/woocommerce-subscriptions/blob/2.2.18/includes/class-wc-subscription.php#L2056) check not working while sending plain text emails because the `woocommerce_email_header` and `woocommerce_email_footer` actions aren't triggered in plain text emails. 
