### PR TITLE
Check arg exists when determining if template needs to be overridden

### DIFF
--- a/includes/class-wcsg-template-loader.php
+++ b/includes/class-wcsg-template-loader.php
@@ -70,7 +70,7 @@ class WCSG_Template_Loader {
 	 * @since 2.0.0
 	 */
 	public static function get_customer_details_template( $located, $template_name, $args ) {
-		if ( ! wcsg_is_wc_subscriptions_pre( '2.2.19' ) && 'order/order-details-customer.php' === $template_name ) {
+		if ( 'order/order-details-customer.php' === $template_name && isset( $args['order'] ) && ! wcsg_is_wc_subscriptions_pre( '2.2.19' ) ) {
 			$subscription = $args['order'];
 			if ( WCS_Gifting::is_gifted_subscription( $subscription ) && get_current_user_id() == WCS_Gifting::get_recipient_user( $subscription ) ) {
 				$located = wc_locate_template( 'order-details-customer.php', '', plugin_dir_path( WCS_Gifting::$plugin_file ) . 'templates/' );


### PR DESCRIPTION
See #264 for the issue background. 

To replicate, make sure you're running WCS 2.2.19+ and then simply navigate to the **WooCommerce > Status** page. You should receive the following warning: 

```
PHP Notice:  Undefined index: order in /app/public/wp-content/plugins/woocommerce-subscriptions-gifting/includes/class-wcsg-template-loader.php on line 74
```

I've also rearranged the logic a little to be a bit more performance friendly. 

fixes #264